### PR TITLE
Account deletion lifecycle and parent controls

### DIFF
--- a/apps/mobile/app/_layout.jsx
+++ b/apps/mobile/app/_layout.jsx
@@ -86,6 +86,15 @@ export default function RootLayout() {
                   <Stack.Screen name="digest" options={nativeDetailSheetOptions} />
                   <Stack.Screen name="activity" options={nativeDetailSheetOptions} />
                   <Stack.Screen
+                    name="delete-account"
+                    options={{
+                      headerShown: false,
+                      presentation: 'card',
+                      animation: 'slide_from_right',
+                      gestureEnabled: false,
+                    }}
+                  />
+                  <Stack.Screen
                     name="settings-menu"
                     options={{
                       headerShown: false,

--- a/apps/mobile/app/delete-account.jsx
+++ b/apps/mobile/app/delete-account.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
+import DeleteAccountScreen from '../src/DeleteAccountScreen';
 import { ProtectedRoute } from '../src/navigation/RouteGuards';
-import SettingsMenuSheetScreen from '../src/SettingsMenuSheetScreen';
 
-export default function SettingsMenuRoute() {
+export default function DeleteAccountRoute() {
   return (
     <ProtectedRoute
       allowMissingFamily
@@ -13,7 +13,7 @@ export default function SettingsMenuRoute() {
       allowMissingSubscription
       allowReadOnlyArchive
     >
-      <SettingsMenuSheetScreen />
+      <DeleteAccountScreen />
     </ProtectedRoute>
   );
 }

--- a/apps/mobile/src/AuthContext.js
+++ b/apps/mobile/src/AuthContext.js
@@ -1,6 +1,7 @@
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { AppState } from 'react-native';
 
+import { clearDeletedAccountLocalData } from './accountDeletionLocal';
 import { deletePushTokensForSignOut } from './pushNotifications';
 import { supabase } from './supabase';
 
@@ -14,17 +15,34 @@ const AuthContext = createContext({
 export function AuthProvider({ children }) {
   const [session, setSession] = useState(null);
   const [loading, setLoading] = useState(true);
+  const lastUserIdRef = useRef(null);
 
   useEffect(() => {
     let mounted = true;
 
-    supabase.auth.getSession().then(({ data }) => {
+    supabase.auth.getSession().then(async ({ data }) => {
       if (!mounted) return;
-      setSession(data.session ?? null);
+      let nextSession = data.session ?? null;
+      if (nextSession) {
+        const { error } = await supabase.auth.getUser();
+        if (isRevokedSessionError(error)) {
+          await clearDeletedAccountLocalData({ userId: nextSession.user?.id });
+          await supabase.auth.signOut({ scope: 'local' }).catch(() => undefined);
+          nextSession = null;
+        }
+      }
+      if (!mounted) return;
+      lastUserIdRef.current = nextSession?.user?.id || null;
+      setSession(nextSession);
       setLoading(false);
     });
 
-    const { data: sub } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+    const { data: sub } = supabase.auth.onAuthStateChange((event, nextSession) => {
+      const previousUserId = lastUserIdRef.current;
+      lastUserIdRef.current = nextSession?.user?.id || null;
+      if (event === 'SIGNED_OUT' && previousUserId) {
+        clearDeletedAccountLocalData({ userId: previousUserId }).catch(() => undefined);
+      }
       setSession(nextSession ?? null);
     });
 
@@ -51,6 +69,7 @@ export function AuthProvider({ children }) {
       loading,
       signOut: async () => {
         await deletePushTokensForSignOut({ userId: session?.user?.id });
+        await clearDeletedAccountLocalData({ userId: session?.user?.id });
         return supabase.auth.signOut();
       },
     }),
@@ -62,4 +81,12 @@ export function AuthProvider({ children }) {
 
 export function useAuth() {
   return useContext(AuthContext);
+}
+
+function isRevokedSessionError(error) {
+  if (!error) return false;
+  return [401, 403, 404].includes(Number(error.status))
+    || ['bad_jwt', 'session_not_found', 'refresh_token_not_found', 'user_not_found'].includes(
+      String(error.code || ''),
+    );
 }

--- a/apps/mobile/src/DeleteAccountScreen.js
+++ b/apps/mobile/src/DeleteAccountScreen.js
@@ -181,11 +181,17 @@ export default function DeleteAccountScreen() {
               </View>
               <View style={styles.cardHeadingCopy}>
                 <Title style={styles.cardTitle}>{ACCOUNT_DELETION_COPY.exportFirst}</Title>
-                <Caption>Save a local copy of your parent-approved archive before continuing.</Caption>
+                <Caption>{ACCOUNT_DELETION_COPY.exportScope}</Caption>
               </View>
             </View>
             <Spacer h={space.md} />
             <Button variant="ghost" onPress={openExport}>Open archive export</Button>
+            {preview.soleWriterCount > 1 ? (
+              <>
+                <Spacer h={space.sm} />
+                <Caption>{ACCOUNT_DELETION_COPY.multipleArchives}</Caption>
+              </>
+            ) : null}
           </Card>
 
           <Card variant="muted">

--- a/apps/mobile/src/DeleteAccountScreen.js
+++ b/apps/mobile/src/DeleteAccountScreen.js
@@ -1,0 +1,346 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Alert, Linking, Platform, Pressable, StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@react-native-vector-icons/ionicons';
+
+import {
+  ACCOUNT_DELETION_COPY,
+  canSubmitAccountDeletion,
+  createDeletionRequestId,
+  deletionImpactLines,
+  normalizeDeletionPreview,
+} from './accountDeletionModel';
+import {
+  deleteAccount,
+  getAccountDeletionPreview,
+  sendAccountDeletionCode,
+} from './accountDeletion';
+import { clearDeletedAccountLocalData } from './accountDeletionLocal';
+import { useAuth } from './AuthContext';
+import { useBilling } from './BillingContext';
+import {
+  createBillingPortal,
+  openManageSubscription,
+} from './billing';
+import { useFamily } from './FamilyContext';
+import { supabase } from './supabase';
+import {
+  Body,
+  Button,
+  Caption,
+  Card,
+  Eyebrow,
+  Field,
+  GlassButton,
+  Screen,
+  Spacer,
+  Title,
+  radius,
+  space,
+  useTheme,
+} from './ui';
+
+const EMPTY_PREVIEW = normalizeDeletionPreview();
+
+export default function DeleteAccountScreen() {
+  const router = useRouter();
+  const theme = useTheme();
+  const { user } = useAuth();
+  const { family } = useFamily();
+  const { entitlement } = useBilling();
+  const requestIdRef = useRef(createDeletionRequestId());
+  const [preview, setPreview] = useState(EMPTY_PREVIEW);
+  const [previewLoading, setPreviewLoading] = useState(true);
+  const [previewReady, setPreviewReady] = useState(false);
+  const [step, setStep] = useState('review');
+  const [otp, setOtp] = useState('');
+  const [confirmation, setConfirmation] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState('');
+
+  const loadPreview = useCallback(() => {
+    let alive = true;
+    setPreviewLoading(true);
+    setPreviewReady(false);
+    setNotice('');
+    getAccountDeletionPreview()
+      .then((value) => {
+        if (alive) {
+          setPreview(value);
+          setPreviewReady(true);
+        }
+      })
+      .catch(() => {
+        if (alive) setNotice('Deletion details could not load yet. You can retry before anything is removed.');
+      })
+      .finally(() => {
+        if (alive) setPreviewLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const cancel = loadPreview();
+    return cancel;
+  }, [loadPreview]);
+
+  const openExport = () => {
+    if (!family?.id) {
+      Alert.alert('No family archive yet', 'This account does not have a family archive to export.');
+      return;
+    }
+    router.push({ pathname: '/library', params: { segment: 'export' } });
+  };
+
+  const manageSubscription = async () => {
+    try {
+      if (entitlement?.source === 'stripe' && family?.id) {
+        const url = await createBillingPortal({ familyId: family.id });
+        if (url) {
+          await Linking.openURL(url);
+          return;
+        }
+      }
+      await openManageSubscription({ source: entitlement?.source, platform: Platform.OS });
+    } catch {
+      Alert.alert('Could not open subscription settings', 'Open your device subscription settings and cancel there if needed.');
+    }
+  };
+
+  const sendCode = async () => {
+    if (!user?.email || busy) return;
+    setBusy(true);
+    setNotice('');
+    try {
+      await sendAccountDeletionCode(user.email);
+      setStep('confirm');
+      setNotice(`A fresh 6-digit code was sent to ${user.email}.`);
+    } catch (error) {
+      setNotice(error?.message || 'Could not send a deletion code.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const submitDeletion = async () => {
+    if (!canSubmitAccountDeletion({ otp, confirmation, busy }) || !user?.email) return;
+    setBusy(true);
+    setNotice('Removing this account and its private state…');
+    try {
+      await deleteAccount({
+        requestId: requestIdRef.current,
+        email: user.email,
+        otp,
+        confirmation,
+      });
+      const local = await clearDeletedAccountLocalData({
+        familyId: family?.id,
+        userId: user.id,
+      });
+      await supabase.auth.signOut({ scope: 'local' }).catch(() => undefined);
+      router.replace('/welcome');
+      Alert.alert(
+        'Account deleted',
+        local.cleared
+          ? 'Your Our Little World account was deleted. Photos and videos in your device library were not changed.'
+          : 'Your account was deleted. Reinstall the app before another sign-in to clear the remaining local cache on this device.',
+      );
+    } catch (error) {
+      setNotice(error?.message || 'Account deletion did not finish. Send a fresh code and try again.');
+      setOtp('');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const impactLines = deletionImpactLines(preview);
+  const canDelete = canSubmitAccountDeletion({ otp, confirmation, busy });
+
+  return (
+    <Screen scroll keyboard variant="warm" contentStyle={styles.content}>
+      <View style={styles.header}>
+        <GlassButton
+          icon="chevron-back"
+          onPress={() => router.back()}
+          accessibilityLabel="Go back"
+        />
+        <View style={styles.headerCopy}>
+          <Eyebrow>Account privacy</Eyebrow>
+          <Title>{ACCOUNT_DELETION_COPY.title}</Title>
+        </View>
+      </View>
+
+      {step === 'review' ? (
+        <>
+          <Card>
+            <View style={styles.cardHeading}>
+              <View style={[styles.iconWrap, { backgroundColor: theme.colors.primarySoft }]}>
+                <Ionicons name="download-outline" size={20} color={theme.semantic.primary} />
+              </View>
+              <View style={styles.cardHeadingCopy}>
+                <Title style={styles.cardTitle}>{ACCOUNT_DELETION_COPY.exportFirst}</Title>
+                <Caption>Save a local copy of your parent-approved archive before continuing.</Caption>
+              </View>
+            </View>
+            <Spacer h={space.md} />
+            <Button variant="ghost" onPress={openExport}>Open archive export</Button>
+          </Card>
+
+          <Card variant="muted">
+            <Eyebrow>What happens</Eyebrow>
+            <Spacer h={space.md} />
+            {previewLoading ? <Body>Checking your family role…</Body> : impactLines.map((line) => (
+              <ImpactRow key={line} text={line} color={theme.semantic.text} />
+            ))}
+            <Spacer h={space.md} />
+            <Body>{ACCOUNT_DELETION_COPY.cameraRoll}</Body>
+            <Spacer h={space.sm} />
+            <Body>{ACCOUNT_DELETION_COPY.sharedHistory}</Body>
+            <Spacer h={space.sm} />
+            <Caption>{ACCOUNT_DELETION_COPY.legalRetention}</Caption>
+          </Card>
+
+          {(preview.storeSubscriptionActionRequired || ['apple', 'google'].includes(entitlement?.source)) ? (
+            <Card>
+              <Eyebrow>Store subscription</Eyebrow>
+              <Spacer h={space.sm} />
+              <Body>{ACCOUNT_DELETION_COPY.storeSubscription}</Body>
+              <Spacer h={space.md} />
+              <Button variant="ghost" onPress={manageSubscription}>Manage store subscription</Button>
+            </Card>
+          ) : null}
+
+          {(preview.stripeCancellationRequired || entitlement?.source === 'stripe') ? (
+            <Card>
+              <Eyebrow>Website subscription</Eyebrow>
+              <Spacer h={space.sm} />
+              <Body>{ACCOUNT_DELETION_COPY.stripeSubscription}</Body>
+            </Card>
+          ) : null}
+
+          {!previewReady && !previewLoading ? (
+            <Button variant="ghost" onPress={loadPreview}>Retry deletion details</Button>
+          ) : null}
+
+          <Button onPress={sendCode} loading={busy} disabled={busy || !user?.email || !previewReady}>
+            Send deletion code
+          </Button>
+        </>
+      ) : (
+        <>
+          <Card>
+            <Eyebrow>Final confirmation</Eyebrow>
+            <Spacer h={space.sm} />
+            <Title style={styles.cardTitle}>Permanently delete this account</Title>
+            <Spacer h={space.sm} />
+            <Body>{ACCOUNT_DELETION_COPY.finalWarning}</Body>
+            <Spacer h={space.lg} />
+            <Field
+              label="6-digit email code"
+              value={otp}
+              onChangeText={(value) => setOtp(value.replace(/\D/g, '').slice(0, 6))}
+              placeholder="000000"
+              inputProps={{
+                keyboardType: 'number-pad',
+                textContentType: 'oneTimeCode',
+                autoComplete: 'one-time-code',
+              }}
+            />
+            <Spacer h={space.md} />
+            <Field
+              label="Type DELETE"
+              value={confirmation}
+              onChangeText={setConfirmation}
+              placeholder="DELETE"
+              autoCapitalize="characters"
+              inputProps={{ autoCorrect: false, spellCheck: false }}
+            />
+          </Card>
+
+          <Pressable onPress={sendCode} disabled={busy} accessibilityRole="button">
+            <Caption style={{ color: theme.semantic.primary }}>
+              Send a fresh code
+            </Caption>
+          </Pressable>
+
+          <Button
+            variant="danger"
+            onPress={submitDeletion}
+            loading={busy}
+            disabled={!canDelete}
+            testID="confirm-account-deletion"
+          >
+            Permanently delete account
+          </Button>
+        </>
+      )}
+
+      {notice ? (
+        <View style={[styles.notice, { backgroundColor: theme.semantic.cardAlt, borderColor: theme.semantic.border }]}>
+          <Caption>{notice}</Caption>
+        </View>
+      ) : null}
+    </Screen>
+  );
+}
+
+function ImpactRow({ text, color }) {
+  return (
+    <View style={styles.impactRow}>
+      <Ionicons name="remove-circle-outline" size={18} color={color} />
+      <Body style={styles.impactText}>{text}</Body>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingTop: space.lg,
+    paddingBottom: space.xxl,
+    gap: space.lg,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: space.md,
+  },
+  headerCopy: {
+    flex: 1,
+    gap: 2,
+  },
+  cardHeading: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: space.md,
+  },
+  cardHeadingCopy: {
+    flex: 1,
+    gap: 2,
+  },
+  cardTitle: {
+    fontSize: 22,
+  },
+  iconWrap: {
+    width: 42,
+    height: 42,
+    borderRadius: radius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  impactRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: space.sm,
+    marginBottom: space.sm,
+  },
+  impactText: {
+    flex: 1,
+  },
+  notice: {
+    padding: space.md,
+    borderRadius: radius.lg,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+});

--- a/apps/mobile/src/FamilyOnboardingScreen.js
+++ b/apps/mobile/src/FamilyOnboardingScreen.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { View, StyleSheet, Image } from 'react-native';
 import * as Linking from 'expo-linking';
+import { useRouter } from 'expo-router';
 
 import {
   Card,
@@ -28,6 +29,7 @@ import RelationshipRolePicker from './RelationshipRolePicker';
  *      ourlittleworld://invite/CODE
  */
 export default function FamilyOnboardingScreen({ route }) {
+  const router = useRouter();
   const { refresh } = useFamily();
   const theme = useTheme();
   const [mode, setMode] = useState('chooser');
@@ -140,6 +142,10 @@ export default function FamilyOnboardingScreen({ route }) {
               onSubmit={onJoin}
             />
           ) : null}
+
+          <Button variant="quiet" onPress={() => router.push('/settings-menu')}>
+            Account settings
+          </Button>
         </V>
       </Screen>
     </View>

--- a/apps/mobile/src/PurchaseScreen.js
+++ b/apps/mobile/src/PurchaseScreen.js
@@ -448,6 +448,9 @@ export default function PurchaseScreen() {
         <Pressable onPress={() => Linking.openURL('https://ourlittleworld.me/privacy/')} style={styles.textAction}>
           <Caption style={{ color: theme.semantic.primary }}>Privacy</Caption>
         </Pressable>
+        <Pressable onPress={() => router.push('/settings-menu')} style={styles.textAction}>
+          <Caption style={{ color: theme.semantic.primary }}>Account settings</Caption>
+        </Pressable>
       </View>
 
       <View style={[styles.featurePanel, { backgroundColor: theme.semantic.card, borderColor: theme.semantic.border }, shadow.whisper]}>

--- a/apps/mobile/src/SettingsMenuSheetScreen.js
+++ b/apps/mobile/src/SettingsMenuSheetScreen.js
@@ -102,7 +102,7 @@ export default function SettingsMenuSheetScreen() {
   const theme = useTheme();
   const { family, refresh: refreshFamily } = useFamily();
   const { entitlement, refresh: refreshBilling, redeemCode } = useBilling();
-  const { user } = useAuth();
+  const { user, signOut } = useAuth();
   const [ritualSettings, setRitualSettings] = useState(() => normalizeRitualSettings(DEFAULT_RITUAL_SETTINGS));
   const [notificationPreferences, setNotificationPreferences] = useState(defaultNotificationPreferences);
   const [settingsCounts, setSettingsCounts] = useState(DEFAULT_SETTINGS_COUNTS);
@@ -356,6 +356,23 @@ export default function SettingsMenuSheetScreen() {
 
   const contactSupport = () => {
     Linking.openURL(`mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent('Our Little World billing help')}`);
+  };
+
+  const confirmSignOut = () => {
+    Alert.alert(
+      'Sign out?',
+      'You can sign back in any time. Your saved family archive stays in Our Little World; private drafts and on-device discovery are cleared from this device.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Sign out',
+          style: 'destructive',
+          onPress: () => signOut().catch((error) => {
+            Alert.alert('Could not sign out', error?.message || 'Try again.');
+          }),
+        },
+      ],
+    );
   };
 
   return (
@@ -665,6 +682,25 @@ export default function SettingsMenuSheetScreen() {
               onReview={() => go({ pathname: '/library', params: { segment: 'search' } })}
             />
           ) : null}
+        </View>
+
+        <View>
+          <Eyebrow>account</Eyebrow>
+          <View style={styles.menuList}>
+            <MenuItem
+              icon="log-out-outline"
+              label="Sign out"
+              detail={user?.email || 'Keep this account and sign out on this device'}
+              onPress={confirmSignOut}
+            />
+            <MenuItem
+              icon="trash-outline"
+              label="Delete account"
+              detail="Export, review the impact, then permanently delete"
+              tint={theme.colors.danger}
+              onPress={() => router.push('/delete-account')}
+            />
+          </View>
         </View>
       </ScrollView>
     </Screen>

--- a/apps/mobile/src/SetupScreen.js
+++ b/apps/mobile/src/SetupScreen.js
@@ -161,7 +161,7 @@ export default function SetupScreen() {
   const onSignOut = async () => {
     Alert.alert(
       'Sign out?',
-      "You can sign back in any time. Your moments stay safe in the cloud.",
+      "You can sign back in any time. Saved moments stay in Our Little World; private drafts and on-device discovery are cleared from this device.",
       [
         { text: 'Cancel', style: 'cancel' },
         {
@@ -268,15 +268,15 @@ export default function SetupScreen() {
           {isFirstSetup ? 'Continue' : 'Save changes'}
         </Button>
 
-        {!isFirstSetup ? (
-          <Card variant="muted">
-            <Eyebrow>Account</Eyebrow>
-            <Spacer h={space.md} />
-            <Body>Signed in as {user?.email || '—'}</Body>
-            <Spacer h={space.lg} />
-            <Button variant="ghost" onPress={onSignOut}>Sign out</Button>
-          </Card>
-        ) : null}
+        <Card variant="muted">
+          <Eyebrow>Account</Eyebrow>
+          <Spacer h={space.md} />
+          <Body>Signed in as {user?.email || '—'}</Body>
+          <Spacer h={space.lg} />
+          <Button variant="ghost" onPress={onSignOut}>Sign out</Button>
+          <Spacer h={space.sm} />
+          <Button variant="quiet" onPress={() => router.push('/delete-account')}>Delete account</Button>
+        </Card>
       </V>
     </Screen>
   );

--- a/apps/mobile/src/accountDeletion.js
+++ b/apps/mobile/src/accountDeletion.js
@@ -1,0 +1,50 @@
+import { supabase } from './supabase';
+import { normalizeDeletionPreview } from './accountDeletionModel';
+
+export async function getAccountDeletionPreview() {
+  const { data, error } = await supabase.functions.invoke('delete-account', {
+    body: { action: 'preview' },
+  });
+  if (error) throw new Error(await functionErrorMessage(error, 'Could not load account deletion details.'));
+  return normalizeDeletionPreview(data?.preview);
+}
+
+export async function sendAccountDeletionCode(email) {
+  const address = String(email || '').trim().toLowerCase();
+  if (!address) throw new Error('This account has no email address.');
+  const { error } = await supabase.auth.signInWithOtp({
+    email: address,
+    options: { shouldCreateUser: false },
+  });
+  if (error) throw new Error('Could not send a fresh deletion code. Try again.');
+  return { sent: true, email: address };
+}
+
+export async function deleteAccount({
+  requestId,
+  email,
+  otp,
+  confirmation,
+}) {
+  const { data, error } = await supabase.functions.invoke('delete-account', {
+    body: {
+      action: 'delete',
+      requestId,
+      email: String(email || '').trim().toLowerCase(),
+      otp: String(otp || '').replace(/\s/g, ''),
+      confirmation: String(confirmation || '').trim(),
+    },
+  });
+  if (error) throw new Error(await functionErrorMessage(error, 'Account deletion did not finish. Nothing new was shared; try again.'));
+  if (!data?.completed) throw new Error('Account deletion did not finish. Try again.');
+  return data;
+}
+
+async function functionErrorMessage(error, fallback) {
+  try {
+    const payload = await error?.context?.json?.();
+    return payload?.error || payload?.message || fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/apps/mobile/src/accountDeletionLocal.js
+++ b/apps/mobile/src/accountDeletionLocal.js
@@ -1,0 +1,55 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { accountDeletionAsyncStorageKeys } from './accountDeletionModel';
+import { clearAllAccountCaches } from './mediaDb';
+import * as Scan from './scanController';
+import { purgeSharedAnnotationVoiceDrafts } from './sharedAnnotationDraftStore';
+import { purgeTonightVoiceDrafts } from './tonightVoiceDrafts';
+
+export async function clearDeletedAccountLocalData({ familyId, userId } = {}) {
+  const failures = [];
+
+  try {
+    Scan.reset();
+  } catch (error) {
+    failures.push(error);
+  }
+
+  try {
+    clearAllAccountCaches();
+  } catch (error) {
+    failures.push(error);
+  }
+
+  try {
+    const keys = await AsyncStorage.getAllKeys();
+    const accountKeys = accountDeletionAsyncStorageKeys(keys, { familyId, userId });
+    if (accountKeys.length) await AsyncStorage.multiRemove(accountKeys);
+  } catch (error) {
+    failures.push(error);
+  }
+
+  const draftResults = await Promise.allSettled([
+    purgeTonightVoiceDrafts(),
+    purgeSharedAnnotationVoiceDrafts(),
+    cancelAccountNotifications(),
+  ]);
+  draftResults.forEach((result) => {
+    if (result.status === 'rejected') failures.push(result.reason);
+  });
+
+  return {
+    cleared: failures.length === 0,
+    failureCount: failures.length,
+  };
+}
+
+async function cancelAccountNotifications() {
+  try {
+    const Notifications = require('expo-notifications');
+    await Notifications.cancelAllScheduledNotificationsAsync?.();
+    await Notifications.setBadgeCountAsync?.(0);
+  } catch {
+    // Older development clients may not contain the optional native module.
+  }
+}

--- a/apps/mobile/src/accountDeletionModel.js
+++ b/apps/mobile/src/accountDeletionModel.js
@@ -1,0 +1,85 @@
+export const ACCOUNT_DELETION_CONFIRMATION = 'DELETE';
+
+export const ACCOUNT_DELETION_COPY = Object.freeze({
+  title: 'Delete your account',
+  exportFirst: 'Export first',
+  cameraRoll: 'Photos and videos in your device library are never deleted.',
+  sharedHistory: 'If another co-parent remains, the family memories you kept together stay with them and your attribution is removed.',
+  soleWriter: 'Families where you are the only co-parent, including their stored media, will be permanently deleted.',
+  circle: 'View-only family access will be removed without deleting that family’s memories.',
+  storeSubscription: 'Deleting your account does not cancel an Apple App Store or Google Play subscription. Cancel it in your store subscription settings.',
+  stripeSubscription: 'A website subscription owned by this account will be canceled during deletion.',
+  legalRetention: 'Minimum billing and fraud-prevention records may be retained where legally required. They do not include your family memory content.',
+  finalWarning: 'This cannot be undone. Type DELETE and enter the fresh email code to continue.',
+});
+
+export function normalizeDeletionPreview(value = {}) {
+  return {
+    familyCount: nonNegativeInteger(value.familyCount ?? value.family_count),
+    soleWriterCount: nonNegativeInteger(value.soleWriterCount ?? value.sole_writer_count),
+    additionalWriterCount: nonNegativeInteger(value.additionalWriterCount ?? value.additional_writer_count),
+    circleCount: nonNegativeInteger(value.circleCount ?? value.circle_count),
+    storeSubscriptionActionRequired: Boolean(
+      value.storeSubscriptionActionRequired ?? value.store_subscription_action_required
+    ),
+    stripeCancellationRequired: Boolean(
+      value.stripeCancellationRequired ?? value.stripe_cancellation_required
+    ),
+  };
+}
+
+export function deletionImpactLines(preview = {}) {
+  const normalized = normalizeDeletionPreview(preview);
+  const lines = [];
+  if (normalized.soleWriterCount) {
+    lines.push(`${normalized.soleWriterCount} ${plural(normalized.soleWriterCount, 'family archive')} permanently deleted`);
+  }
+  if (normalized.additionalWriterCount) {
+    lines.push(`${normalized.additionalWriterCount} shared ${plural(normalized.additionalWriterCount, 'family archive')} preserved for another co-parent`);
+  }
+  if (normalized.circleCount) {
+    lines.push(`${normalized.circleCount} view-only ${plural(normalized.circleCount, 'membership')} removed`);
+  }
+  if (!lines.length) lines.push('Your sign-in and account data permanently deleted');
+  return lines;
+}
+
+export function canSubmitAccountDeletion({ otp, confirmation, busy = false } = {}) {
+  return !busy
+    && /^\d{6}$/.test(String(otp || '').replace(/\s/g, ''))
+    && String(confirmation || '').trim() === ACCOUNT_DELETION_CONFIRMATION;
+}
+
+export function accountDeletionAsyncStorageKeys(keys = [], { familyId, userId } = {}) {
+  const familyToken = familyId ? `:${familyId}` : null;
+  const userToken = userId ? `:${userId}` : null;
+  return [...new Set((keys || []).filter((key) => {
+    const value = String(key || '');
+    if (value === 'olw:theme-preferences:v1') return false;
+    if (value.startsWith('olw:')) return true;
+    if (familyToken && value.includes(familyToken)) return true;
+    return Boolean(userToken && value.includes(userToken));
+  }))];
+}
+
+export function createDeletionRequestId(
+  randomUuid = globalThis.crypto?.randomUUID?.bind(globalThis.crypto),
+  getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto),
+) {
+  if (randomUuid) return randomUuid();
+  if (!getRandomValues) throw new Error('Secure account deletion confirmation is unavailable.');
+  const bytes = getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = [...bytes].map((value) => value.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function plural(count, singular) {
+  return count === 1 ? singular : `${singular}s`;
+}
+
+function nonNegativeInteger(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.max(0, Math.floor(number)) : 0;
+}

--- a/apps/mobile/src/accountDeletionModel.js
+++ b/apps/mobile/src/accountDeletionModel.js
@@ -3,6 +3,8 @@ export const ACCOUNT_DELETION_CONFIRMATION = 'DELETE';
 export const ACCOUNT_DELETION_COPY = Object.freeze({
   title: 'Delete your account',
   exportFirst: 'Export first',
+  exportScope: 'Create and verify the current family export before continuing. The export screen lists its current video, audio, and sharing limits.',
+  multipleArchives: 'Deletion applies across your family roles. Export each sole-parent family archive you want to keep before continuing.',
   cameraRoll: 'Photos and videos in your device library are never deleted.',
   sharedHistory: 'If another co-parent remains, the family memories you kept together stay with them and your attribution is removed.',
   soleWriter: 'Families where you are the only co-parent, including their stored media, will be permanently deleted.',

--- a/apps/mobile/src/mediaDb.js
+++ b/apps/mobile/src/mediaDb.js
@@ -203,6 +203,11 @@ export function removeCachedMedia({ familyId, assetOwnerUserId, assetId }) {
 export function clearFamilyCache(familyId) {
   if (!familyId) return;
   const database = getDb();
+  database.runSync(
+    `delete from media_variant_cache
+     where media_id in (select media_id from media_items where family_id = ?)`,
+    [familyId],
+  );
   database.runSync('delete from media_items where family_id = ?', [familyId]);
   database.runSync('delete from media_sync_cursors where family_id = ?', [familyId]);
   database.runSync('delete from upload_jobs where family_id = ?', [familyId]);
@@ -211,6 +216,23 @@ export function clearFamilyCache(familyId) {
   database.runSync('delete from candidate_cluster_members where family_id = ?', [familyId]);
   database.runSync('delete from candidate_clusters where family_id = ?', [familyId]);
   database.runSync('delete from discovery_candidates where family_id = ?', [familyId]);
+  database.runSync('delete from family_saved_day_facts where family_id = ?', [familyId]);
+}
+
+/** Removes every account-scoped local cache before a deleted user leaves the device. */
+export function clearAllAccountCaches() {
+  const database = getDb();
+  database.withTransactionSync(() => {
+    database.runSync('delete from media_variant_cache');
+    database.runSync('delete from media_items');
+    database.runSync('delete from media_sync_cursors');
+    database.runSync('delete from upload_jobs');
+    database.runSync('delete from local_asset_mappings');
+    database.runSync('delete from nightly_review_sessions');
+    database.runSync('delete from candidate_clusters');
+    database.runSync('delete from discovery_candidates');
+    database.runSync('delete from family_saved_day_facts');
+  });
 }
 
 // ─── Private local-to-shared media identity ─────────────────────────────────

--- a/apps/mobile/src/sharedAnnotationDraftStore.js
+++ b/apps/mobile/src/sharedAnnotationDraftStore.js
@@ -39,6 +39,10 @@ export async function deleteSharedAnnotationVoiceDraft(uri) {
   return true;
 }
 
+export async function purgeSharedAnnotationVoiceDrafts() {
+  await FileSystem.deleteAsync(DIRECTORY, { idempotent: true });
+}
+
 export function isSharedAnnotationVoiceDraft(uri) {
   return typeof uri === 'string' && uri.startsWith(DIRECTORY);
 }

--- a/apps/mobile/src/tonightVoiceDrafts.js
+++ b/apps/mobile/src/tonightVoiceDrafts.js
@@ -20,6 +20,10 @@ export async function deleteTonightVoiceDraft(uri) {
   return true;
 }
 
+export async function purgeTonightVoiceDrafts() {
+  await FileSystem.deleteAsync(TONIGHT_VOICE_DRAFT_DIRECTORY, { idempotent: true });
+}
+
 export async function cleanupOrphanedTonightVoiceDrafts(activeUris = []) {
   const activeNames = new Set(activeUris.filter(isTonightVoiceDraft).map(fileName));
   const info = await FileSystem.getInfoAsync(TONIGHT_VOICE_DRAFT_DIRECTORY);

--- a/apps/mobile/src/ui/Button.js
+++ b/apps/mobile/src/ui/Button.js
@@ -13,6 +13,7 @@ import useReducedMotion from './useReducedMotion';
  *   variant="ghost"       transparent + 1.5px coral border + coral text.
  *   variant="quiet"       no background, just coral text. For tertiary actions.
  *   variant="dark"        ink fill, cream text. For inverted contexts.
+ *   variant="danger"      destructive red fill, cream text.
  *
  *   size="lg" | "md" | "sm"
  *   icon={<Some/>}        rendered before the label
@@ -121,6 +122,7 @@ function getVariants(theme) {
       fg: theme.isDark ? colors.ink : colors.bg,
       shadow: true,
     },
+    danger:    { bg: colors.danger, fg: colors.onPrimary, shadow: true },
     cream:     { bg: colors.bg,          fg: colors.ink,       shadow: true },
   };
 }

--- a/apps/mobile/tests/unit/accountDeletionContracts.test.js
+++ b/apps/mobile/tests/unit/accountDeletionContracts.test.js
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const root = new URL('../../', import.meta.url);
+
+function source(path) {
+  return readFileSync(new URL(path, root), 'utf8');
+}
+
+test('account deletion remains reachable across lifecycle and entitlement gates', () => {
+  const settingsRoute = source('app/settings-menu.jsx');
+  const deletionRoute = source('app/delete-account.jsx');
+  for (const contract of [
+    'allowMissingFamily',
+    'allowIncompleteSetup',
+    'allowFirstLook',
+    'allowFirstValue',
+    'allowMissingSubscription',
+    'allowReadOnlyArchive',
+  ]) {
+    assert.match(settingsRoute, new RegExp(contract));
+    assert.match(deletionRoute, new RegExp(contract));
+  }
+});
+
+test('deletion UI offers export and has no analytics transport', () => {
+  const screen = source('src/DeleteAccountScreen.js');
+  assert.match(screen, /Open archive export/);
+  assert.match(screen, /Send deletion code/);
+  assert.match(screen, /Permanently delete account/);
+  assert.doesNotMatch(screen, /trackAnalyticsEvent|PostHog|Sentry|captureException/);
+});
+
+test('sign-out and revoked-session paths clear private local account state', () => {
+  const auth = source('src/AuthContext.js');
+  assert.match(auth, /isRevokedSessionError/);
+  assert.match(auth, /event === 'SIGNED_OUT'/);
+  assert.ok((auth.match(/clearDeletedAccountLocalData/g) || []).length >= 3);
+});
+
+test('server contract is service-only, role-locked, and aggregate-audited', () => {
+  const migration = source('../../supabase/migrations/20260724120000_account_deletion_lifecycle.sql');
+  const edge = source('../../supabase/functions/delete-account/index.ts');
+  assert.match(migration, /revoke all on table public\.account_deletion_requests from public, anon, authenticated/);
+  assert.match(migration, /family account deletion is in progress/);
+  assert.match(migration, /account deletion is blocked by a legal hold/);
+  assert.match(edge, /providerCleanupSummary/);
+  assert.doesNotMatch(edge, /console\.(log|warn|error)/);
+});

--- a/apps/mobile/tests/unit/accountDeletionModel.test.js
+++ b/apps/mobile/tests/unit/accountDeletionModel.test.js
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  ACCOUNT_DELETION_COPY,
+  accountDeletionAsyncStorageKeys,
+  canSubmitAccountDeletion,
+  createDeletionRequestId,
+  deletionImpactLines,
+  normalizeDeletionPreview,
+} from '../../src/accountDeletionModel.js';
+
+test('account deletion copy preserves the device-library and shared-history boundaries', () => {
+  assert.match(ACCOUNT_DELETION_COPY.cameraRoll, /never deleted/i);
+  assert.match(ACCOUNT_DELETION_COPY.sharedHistory, /another co-parent remains/i);
+  assert.match(ACCOUNT_DELETION_COPY.storeSubscription, /does not cancel/i);
+  assert.match(ACCOUNT_DELETION_COPY.finalWarning, /cannot be undone/i);
+});
+
+test('account deletion requires a six digit OTP and exact destructive confirmation', () => {
+  assert.equal(canSubmitAccountDeletion({ otp: '123456', confirmation: 'DELETE' }), true);
+  assert.equal(canSubmitAccountDeletion({ otp: '12345', confirmation: 'DELETE' }), false);
+  assert.equal(canSubmitAccountDeletion({ otp: '123456', confirmation: 'delete' }), false);
+  assert.equal(canSubmitAccountDeletion({ otp: '123456', confirmation: 'DELETE', busy: true }), false);
+});
+
+test('preview normalization and impact copy cover sole, co-parent, and circle roles', () => {
+  const preview = normalizeDeletionPreview({
+    family_count: 3,
+    sole_writer_count: 1,
+    additional_writer_count: 1,
+    circle_count: 1,
+    store_subscription_action_required: true,
+  });
+  assert.deepEqual(preview, {
+    familyCount: 3,
+    soleWriterCount: 1,
+    additionalWriterCount: 1,
+    circleCount: 1,
+    storeSubscriptionActionRequired: true,
+    stripeCancellationRequired: false,
+  });
+  assert.deepEqual(deletionImpactLines(preview), [
+    '1 family archive permanently deleted',
+    '1 shared family archive preserved for another co-parent',
+    '1 view-only membership removed',
+  ]);
+});
+
+test('local purge selection removes account state but preserves theme preference', () => {
+  const familyId = '10000000-0000-4000-8000-000000000001';
+  const userId = '20000000-0000-4000-8000-000000000002';
+  assert.deepEqual(accountDeletionAsyncStorageKeys([
+    'olw:theme-preferences:v1',
+    `olw:reference:${familyId}:${userId}`,
+    `custom:${familyId}:cache`,
+    'unrelated:key',
+  ], { familyId, userId }), [
+    `olw:reference:${familyId}:${userId}`,
+    `custom:${familyId}:cache`,
+  ]);
+});
+
+test('deletion request identity uses secure bytes when randomUUID is unavailable', () => {
+  const id = createDeletionRequestId(null, (bytes) => {
+    bytes.set(Array.from({ length: 16 }, (_, index) => index));
+    return bytes;
+  });
+  assert.equal(id, '00010203-0405-4607-8809-0a0b0c0d0e0f');
+  assert.throws(
+    () => createDeletionRequestId(null, null),
+    /Secure account deletion confirmation is unavailable/,
+  );
+});

--- a/apps/mobile/tests/unit/accountDeletionModel.test.js
+++ b/apps/mobile/tests/unit/accountDeletionModel.test.js
@@ -13,6 +13,8 @@ import {
 test('account deletion copy preserves the device-library and shared-history boundaries', () => {
   assert.match(ACCOUNT_DELETION_COPY.cameraRoll, /never deleted/i);
   assert.match(ACCOUNT_DELETION_COPY.sharedHistory, /another co-parent remains/i);
+  assert.match(ACCOUNT_DELETION_COPY.exportScope, /video, audio, and sharing limits/i);
+  assert.match(ACCOUNT_DELETION_COPY.multipleArchives, /each sole-parent family archive/i);
   assert.match(ACCOUNT_DELETION_COPY.storeSubscription, /does not cancel/i);
   assert.match(ACCOUNT_DELETION_COPY.finalWarning, /cannot be undone/i);
 });

--- a/docs/account-deletion-implementation.md
+++ b/docs/account-deletion-implementation.md
@@ -1,0 +1,93 @@
+# Account Deletion Release-Candidate Handoff
+
+Date: 2026-07-24
+
+Branch: `codex/olw-account-deletion`
+
+Base: clean release lineage `origin/codex/olw-first-look-release` at `5560b74`
+Implementation commits: `dba9fb2`, `5588ff7`, `82d8282`
+
+## Outcome
+
+The prior policy-only deletion gap is implemented end to end in source. Parents can
+reach account controls from every lifecycle gate, export first, see the exact
+role-derived impact, reauthenticate with a fresh email code, and explicitly confirm
+permanent deletion. The server deletes only what the requester’s role owns:
+sole-writer families and app-controlled media are removed; co-parent family history
+stays with the remaining writer and loses the deleted author reference; Circle access
+is removed without changing the family.
+
+The implementation keeps the product invariant intact: private discovery candidates,
+local Photos identifiers, face evidence, fingerprints, queue state, drafts, rejects,
+and selection rationale remain device-only and never enter the deletion service,
+audit ledger, analytics, notifications, or reports.
+
+## Source map
+
+- Parent flow: `apps/mobile/src/DeleteAccountScreen.js`,
+  `accountDeletionModel.js`, `accountDeletion.js`, `accountDeletionLocal.js`.
+- Lifecycle access: `SettingsMenuSheetScreen.js`, `SetupScreen.js`,
+  `FamilyOnboardingScreen.js`, `PurchaseScreen.js`, route guards and stack routes.
+- Local erasure: `mediaDb.js`, `tonightVoiceDrafts.js`,
+  `sharedAnnotationDraftStore.js`.
+- Database/RLS: `supabase/migrations/20260724120000_account_deletion_lifecycle.sql`.
+- Edge: `supabase/functions/delete-account/index.ts` and
+  `_shared/accountDeletion.ts`.
+- Provider orphan safety: `create-stream-upload/index.ts` and
+  `workers/media-gateway/src/accountDeletion.js`; the Worker deletion marker
+  also denies an already-issued original-media session before cache lookup.
+- Reproducible proof: `supabase/tests/account_deletion_lifecycle_test.sql`,
+  Deno tests, mobile unit tests, and `scripts/qa-account-deletion-local.mjs`.
+
+## Evidence captured before handoff
+
+- Frozen dependency install completed.
+- Fresh migration replay and schema lint passed.
+- Account lifecycle pgTAP passed 39 assertions, including sole/additional/Circle
+  classification, writer/membership locks, legal hold, cross-family Storage
+  selection, billing minimization, auth deletion, and shared-author preservation.
+- All repository SQL tests passed 133 assertions; the legacy identity migration
+  replay passed 6 assertions through its host-psql harness.
+- Edge and Worker checks passed; ten focused Deno tests passed, including the
+  deleted-family marker overriding a valid media session before cache lookup.
+- Repository tests passed with all 448 mobile unit contracts; repository lint,
+  typecheck, build, the direct web production build, Expo lint, and Expo Doctor
+  `20/20` passed.
+- The real local HTTP journey passed with synthetic Auth users, two writers, a
+  sole family, a shared family, Mailpit OTP, Supabase Storage, Edge orchestration,
+  database finalization, and Auth hard deletion. Aggregate result: sole family and
+  object deleted; shared family/object preserved; deleted membership removed;
+  shared moment preserved with null attribution.
+- Current Wrangler bundled the Worker successfully in dry-run mode. No Worker,
+  Edge Function, schema, or binary was deployed to production.
+- Provider readback found no Supabase preview branch. Production has
+  `create-stream-upload` version 20 but no `delete-account` function, and the
+  current media Worker deployment predates this branch. The latest EAS store build
+  remains iOS `1.1.0` build `1.1.11` from base commit `5560b74`; it does not contain
+  account deletion.
+- The deterministic part of `pnpm smoke:mobile` passed `25/25`. Maestro stopped
+  at its documented credential boundary because `OLW_SMOKE_DEV_CODE` is not
+  present in an authorized local test profile. No credential was logged or invented.
+
+## Release boundary
+
+This branch is implementation and rehearsal evidence, not production evidence.
+Before claiming account deletion in public product/marketing, complete the
+non-production provider rehearsal, deploy in the authorized order from
+`docs/account-deletion-operations.md`, build/install the exact signed client, and
+exercise a synthetic physical-device deletion. A real family deletion remains a
+parent action and must never be used as release QA.
+
+There is currently no Supabase preview branch on the linked project, so a
+representative remote schema/provider rehearsal could not be performed without
+creating provider state. That creation, the shared deletion secret, and every
+production mutation remain explicit release-authority boundaries.
+
+Production actions still awaiting explicit authorization:
+
+1. apply the additive migration;
+2. set the new shared Worker/Edge deletion secret;
+3. deploy the media Worker and affected Edge Functions;
+4. build/upload the dependent signed client to an internal channel;
+5. run provider-backed synthetic deletion and physical-device proof;
+6. promote any public store release.

--- a/docs/account-deletion-operations.md
+++ b/docs/account-deletion-operations.md
@@ -1,0 +1,95 @@
+# Account Deletion Operations
+
+This runbook operates the implemented account-deletion lifecycle. It does not grant
+production authority. Production migration, Edge/Worker deployment, secret changes,
+or deletion of a real account require explicit action-specific authorization.
+
+## Components and configuration names
+
+| Owner | Source | Runtime configuration |
+| --- | --- | --- |
+| Database/RLS | `20260724120000_account_deletion_lifecycle.sql` | Supabase project connection |
+| Edge orchestration | `supabase/functions/delete-account` | Supabase built-ins plus existing `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, and `STRIPE_SECRET_KEY`; new `MEDIA_GATEWAY_INTERNAL_URL`, `MEDIA_DELETION_SECRET` |
+| Stream orphan tracking | `supabase/functions/create-stream-upload` | Existing Cloudflare credentials |
+| R2 erasure | `workers/media-gateway/src/accountDeletion.js` | Existing `ORIGINALS` binding; new secret `MEDIA_DELETION_SECRET` |
+| Mobile | `/settings-menu`, `/delete-account` | Existing Supabase public client configuration |
+
+`MEDIA_DELETION_SECRET` is the same high-entropy secret on the Edge function and
+media Worker. Set it through provider secret stores, never source, shell arguments,
+reports, or logs. `MEDIA_GATEWAY_INTERNAL_URL` is configuration, not a credential.
+
+## Pre-deployment rehearsal
+
+1. Start a disposable local Supabase stack and replay every migration:
+   `pnpm db:reset:migrations`.
+2. Run all SQL contracts: `supabase test db supabase/tests/*.sql`.
+3. Run Edge/Worker checks and tests:
+   `deno check supabase/functions/delete-account/index.ts
+   supabase/functions/create-stream-upload/index.ts
+   workers/media-gateway/src/index.js` and
+   `deno test supabase/functions/_shared/accountDeletion_test.ts
+   workers/media-gateway/src/accountDeletion_test.js`.
+4. Serve the function locally, then run
+   `pnpm qa:account-deletion:local`. The script refuses a non-local Supabase URL,
+   uses synthetic accounts/media only, consumes a local Mailpit OTP, verifies sole
+   versus shared-family behavior, and removes its fixture.
+5. Validate the Worker bundle without deployment using current Wrangler:
+   `pnpm dlx wrangler@latest deploy --dry-run` from `workers/media-gateway`.
+6. Rehearse the same migration and synthetic role matrix on a named,
+   representative non-production Supabase project before any production action.
+   Record only aggregate outcomes and provider object counts.
+
+## Authorized deployment order
+
+1. Confirm a database backup/PITR point and the exact clean source commit.
+2. Apply the additive account-deletion migration.
+3. Verify function grants, RLS, writer-lock behavior, and old-client compatibility.
+4. Add the shared deletion secret to the media Worker and Edge Function secret
+   stores without printing it.
+5. Deploy the media Worker. Probe the internal route for unauthorized rejection and
+   run an authorized synthetic R2-prefix deletion in non-production.
+   Verify the persistent non-content deletion marker makes a previously valid
+   original-media session return `410` before any cached response.
+6. Deploy `create-stream-upload`, then `delete-account`.
+7. Run the synthetic sole/additional/Circle matrix, Supabase Storage check,
+   Stream/R2 check, Stripe test subscription cancellation, and auth hard-delete in
+   non-production.
+8. Build a clean signed client from the exact commit, distribute only to the
+   authorized internal channel, and exercise export → preview → OTP → `DELETE` →
+   local cleanup on a physical device with a synthetic account. Exercise a second
+   installation too: revoke the account while it is offline, confirm server access
+   stays denied, then reconnect and confirm revoked-session cleanup removes its OLW
+   caches, drafts, notifications, and local session.
+9. Roll out to a limited cohort only after aggregate error/attempt counts remain
+   healthy. No deletion payload or account content enters analytics.
+
+## Retry and recovery
+
+- `prepared` or `cleanup_failed`: reauthenticate and retry. The stable user-owned
+  request ledger is reused, roles/providers are re-inventoried, and locks renew.
+- `provider_cleaned`: retry database finalization; do not recreate provider content.
+- `database_deleted` or `auth_deleting`: retry hard Auth deletion. Shared records
+  and retained legal rows are already detached/minimized.
+- `completed`: return success idempotently.
+- `blocked_legal_hold`: do not touch providers or data. Escalate through the legal
+  process; lifting a hold is a separate authorized database action.
+- Expired family lock: retry from inventory. Never bypass or lengthen a lock by
+  weakening RLS.
+
+The failure response to a parent stays generic. Detailed provider messages, paths,
+emails, OTPs, media identifiers, and content must not enter logs or support tickets.
+Operational reconciliation may query the service-only ledger for status, attempt
+count, aggregate provider counts, and bounded error code.
+
+## Rollback and forward fix
+
+The schema is additive. If the client or orchestration must be halted, disable the
+parent entry point or restore the previous compatible Edge/Worker version while
+leaving the tables and nullable provider columns intact. Release expired locks by
+normal expiry or a narrowly authorized request-level operation after checking the
+ledger.
+
+Never roll back by deleting families, account-deletion ledgers, retained billing
+records, annotations, collections, parent exclusions, candidate ledgers, or shared
+authorship. If provider cleanup completed but database finalization did not, forward
+fix the request; do not restore deleted media into a family.

--- a/docs/account-deletion-policy.md
+++ b/docs/account-deletion-policy.md
@@ -1,9 +1,11 @@
 # Account Deletion Policy
 
-Status: policy and implementation task. The destructive flow is not implemented in
-this PRD pass.
+Status: implemented as a release-candidate change on
+`codex/olw-account-deletion`; production migration, Edge/Worker deployment, and a
+dependent signed client remain separate authorization and release gates.
 
-Tracked implementation task: **K7/J3 Delete account flow**.
+Tracked implementation task: **K7/J3 Delete account flow**. Operational order and
+recovery are defined in `docs/account-deletion-operations.md`.
 
 ## Required Product Flow
 
@@ -62,8 +64,11 @@ deleted. Only Our Little World account, family, and stored media data are in sco
 
 ## Billing, Gifts, And Legal Retention
 
-- Stripe, Apple, and other payment-provider records are not directly deleted by the
-  app flow. Keep only the minimum local billing identifiers needed for receipts,
+- The server cancels active Stripe subscriptions owned by the deleting account
+  before database finalization. Apple App Store and Google Play subscriptions cannot
+  be canceled by the app; the parent is shown the store-management action before
+  deletion and the final flow does not claim otherwise. Keep only the minimum local
+  billing identifiers needed for receipts,
   refunds, disputes, taxes, fraud prevention, entitlement reconciliation, and legal
   obligations.
 - Redeemed gift access is tied to the family. If the family is deleted by its sole
@@ -97,3 +102,38 @@ deleted. Only Our Little World account, family, and stored media data are in sco
 - The flow clears push tokens and notification rows.
 - The flow preserves required billing/legal records while deleting memory content.
 - Product copy states that camera-roll originals are not deleted.
+
+## Implemented Release-Candidate Contract
+
+- Settings, incomplete setup, no-family onboarding, read-only/lapsed access, and
+  the purchase gate can all reach account controls.
+- The first screen loads a server-derived role preview and fails closed if that
+  preview is unavailable. It offers archive export and provider-specific
+  subscription guidance before a fresh email code is sent.
+- Final deletion requires a six-digit email OTP for the current Supabase user and
+  the exact text `DELETE`. The client never receives admin credentials.
+- `account_deletion_family_locks` closes writer and membership mutations between
+  inventory and finalization. Legal holds stop the flow before provider inventory.
+- Sole-writer provider cleanup recursively verifies the target family prefix in
+  Supabase Storage, inventories/deletes Cloudflare Stream by known UID and family
+  metadata, and asks the media Worker to enumerate and verify the complete R2
+  family prefix. The Worker writes a non-content family deletion marker before
+  erasure and checks it before original-media cache reads, so an existing
+  short-lived media session cannot expose a stale cached original. Provider failure
+  leaves the database and auth account retryable.
+- Database finalization deletes sole-writer families, removes additional-writer and
+  Circle memberships without deleting their family archives, clears user/device
+  server state, minimizes retained billing rows, and then hard-deletes Supabase
+  Auth. Shared authored records survive with nullable attribution.
+- Device cleanup removes every OLW account-scoped AsyncStorage key except the theme,
+  every local SQLite archive/candidate/upload/queue row, temporary voice drafts,
+  scheduled OLW notifications, and the local auth session. It does not touch the
+  device photo library or a parent-created archive export.
+- The initiating device clears immediately. Another device cannot be remotely
+  erased while it is offline, but the deleted Auth identity cannot read or write
+  server data; on launch or the next revoked-session check, that installation
+  clears its OLW private caches, drafts, notifications, and local session.
+- Audit evidence is service-only and aggregate-only: request/family-role
+  identifiers, lifecycle timestamps/status, legal-hold state, attempt/error code,
+  and provider deletion counts. It contains no media paths, authored content,
+  candidate evidence, drafts, or OTP.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,10 +54,24 @@ history lives in `docs/sprint-progress.md`, the backlog in `docs/polish-backlog.
   suggestion `Not this`, photo-stack choices, caption draft use, and book-readiness
   actions stay separate; First suggestion feedback is device-local per family/user and
   does not become a child-identity or face-match negative example.
-- **Account deletion:** destructive deletion is not implemented yet. The required
-  Settings flow, backend role handling, auth deletion, storage/media deletion,
-  billing/gift retention, and legal-retention policy are tracked in
-  `docs/account-deletion-policy.md`.
+- **Account deletion:** `/delete-account` is reachable from account settings across
+  normal, incomplete-setup, no-family, lapsed/read-only, and purchase-gated states.
+  The screen offers export first, loads a service-derived role preview, requires a
+  fresh email OTP plus exact `DELETE`, and emits no analytics. The `delete-account`
+  Edge Function coordinates a service-only, idempotent lifecycle: legal-hold check;
+  per-family lock; role/provider inventory; verified Supabase Storage, Cloudflare
+  Stream, R2, and Stripe cleanup; role-aware database finalization; and hard Auth
+  deletion. Sole-writer families are removed, while additional-writer and Circle
+  families remain and shared authorship is nulled rather than reassigned. The media
+  Worker exposes a secret-authenticated internal R2-prefix deletion route. It writes
+  a non-content deletion marker first and checks that marker before original-media
+  cache reads, invalidating existing short-lived media sessions without storing
+  memory content or private discovery evidence. In addition,
+  `create-stream-upload` records the provider UID before returning a direct-upload
+  URL so an interrupted upload remains discoverable. Local cleanup erases all
+  account-scoped SQLite/AsyncStorage/draft/notification state while preserving the
+  device camera roll and explicit exports. See `docs/account-deletion-policy.md` and
+  `docs/account-deletion-operations.md`.
 - **Export and lapsed subscriptions:** `docs/export-lapsed-subscription-policy.md`
   is the source for the trust copy: memories are never deleted for non-payment;
   lapsed subscriptions become a read-only vault with saved memories viewable and

--- a/docs/sprint-progress.md
+++ b/docs/sprint-progress.md
@@ -2,6 +2,52 @@
 
 Loop state: COMPLETE WITH RECORDED BLOCKERS + INDEPENDENT REVIEW PASS DONE (2026-07-06). Working branch: `polish-sprints`. Source of truth: `docs/polish-backlog.md`.
 
+## Account deletion release candidate (2026-07-24)
+
+Status: implemented and locally rehearsed on isolated branch
+`codex/olw-account-deletion` from clean release base `5560b74`. Implementation
+commits are `dba9fb2`, `5588ff7`, and `82d8282`. No production migration,
+Edge/Worker deployment, signed binary upload, or public-store action was performed.
+
+- Parents can reach account controls from normal settings, incomplete setup,
+  no-family onboarding, lapsed/read-only access, and the purchase gate. The flow
+  opens the current archive export and discloses its video/audio/sharing limits,
+  loads a fail-closed role preview, requires a fresh email OTP plus exact `DELETE`,
+  then clears local SQLite, AsyncStorage, drafts, notifications, and session state.
+- The additive database lifecycle classifies sole writer, additional writer, and
+  Circle roles; checks legal hold before provider inventory; locks affected family
+  writes/membership; preserves shared family records with nullable authorship;
+  minimizes billing/legal rows; and hard-deletes Supabase Auth through a
+  service-only Edge boundary. Its aggregate ledger contains no content, paths, OTP,
+  private candidates, Photos identifiers, face evidence, fingerprints, rationale,
+  rejects, or drafts.
+- Supabase Storage, Cloudflare Stream, R2 originals, and Stripe are cleaned before
+  database finalization. Interrupted Stream direct uploads persist their provider
+  UID. R2 cleanup inventories and verifies the complete family prefix and writes a
+  non-content deletion marker first, so a valid short-lived media token cannot serve
+  a stale cached original.
+- Fresh migration replay and schema lint passed. Account deletion pgTAP passed
+  `39/39`; all database contracts passed `133/133`; legacy opaque-identity replay
+  passed `6/6`; Edge/Worker Deno tests passed `10/10`; mobile tests passed
+  `448/448`; repository lint/typecheck/build, web production build, Expo lint,
+  Expo Doctor `20/20`, Wrangler dry-run, and `git diff --check` passed.
+- The real local HTTP rehearsal used only synthetic users/families, Mailpit OTP,
+  PostgREST, Storage, Edge orchestration, database finalization, and Auth deletion.
+  It deleted the sole family and its object, preserved the shared family/object and
+  remaining writer, removed the target membership, nulled shared attribution, and
+  made the deleted Auth user unavailable.
+- Provider readback found no Supabase preview branch; production has the prior
+  `create-stream-upload` but no `delete-account`, and the current media Worker
+  predates this work. Latest EAS store build `1.1.0` (`1.1.11`) is from base
+  `5560b74` and does not contain deletion. The deterministic mobile smoke passed
+  `25/25`, then Maestro stopped because the authorized local
+  `OLW_SMOKE_DEV_CODE` profile is absent.
+- Remaining release gates are deliberately separate: representative
+  non-production provider rehearsal, secret configuration, authorized deployments,
+  a clean signed internal build, and synthetic physical-device/two-installation
+  deletion proof. Public marketing must not claim in-app deletion until those gates
+  pass.
+
 ## Curated Memory Library audit and delivery plan (2026-07-18)
 
 - Audited the current mobile routes, Today/Add/Our World flows, scan/checkpoint lifecycle, local media database, review state, day-first curation, best-photo and video models, moment enrichment, family-library contract, notifications, analytics, and supporting Supabase schema against the requested daily plus historical curated-memory vision.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "agent:inventory": "bash scripts/agent/repo-inventory.sh",
     "agent:validate": "bash scripts/agent/validate-context.sh",
     "smoke:mobile": "bash scripts/agent/smoke-mobile.sh",
+    "qa:account-deletion:local": "node scripts/qa-account-deletion-local.mjs",
     "dev": "turbo dev",
     "dev:web": "pnpm --filter @ourlittleworld/web dev",
     "dev:mobile": "pnpm --filter @ourlittleworld/mobile dev",

--- a/reports/account-deletion-release-readiness-2026-07-24.html
+++ b/reports/account-deletion-release-readiness-2026-07-24.html
@@ -1,0 +1,327 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Our Little World — Account Deletion Release Readiness</title>
+  <style>
+    :root {
+      --ink: #2f2523;
+      --muted: #6f625e;
+      --paper: #fffaf4;
+      --card: #fff;
+      --line: #eaded4;
+      --coral: #c65f52;
+      --rose: #f5dfd9;
+      --sage: #dfe9df;
+      --amber: #f7e9c9;
+      --danger: #a53f35;
+      --shadow: 0 18px 50px rgba(75, 48, 38, .08);
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      color: var(--ink);
+      background:
+        radial-gradient(circle at 8% 0%, #f8dfd7 0, transparent 30rem),
+        radial-gradient(circle at 92% 12%, #e6eee4 0, transparent 28rem),
+        var(--paper);
+      font: 16px/1.62 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0 80px; }
+    header {
+      min-height: 440px;
+      padding: clamp(36px, 7vw, 80px);
+      border: 1px solid rgba(198, 95, 82, .16);
+      border-radius: 34px;
+      background: rgba(255, 255, 255, .78);
+      box-shadow: var(--shadow);
+      display: grid;
+      align-content: center;
+      gap: 18px;
+    }
+    .eyebrow {
+      color: var(--coral);
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: .14em;
+      text-transform: uppercase;
+    }
+    h1, h2, h3 { line-height: 1.12; letter-spacing: -.025em; }
+    h1 { max-width: 820px; margin: 0; font: 700 clamp(46px, 8vw, 84px)/.98 Georgia, serif; }
+    h2 { margin: 0 0 20px; font: 700 clamp(29px, 4vw, 44px)/1.08 Georgia, serif; }
+    h3 { margin: 0 0 10px; font-size: 19px; }
+    p { margin: 0 0 16px; }
+    .lead { max-width: 760px; color: var(--muted); font-size: clamp(19px, 2.5vw, 25px); }
+    .status {
+      display: inline-flex;
+      width: fit-content;
+      gap: 9px;
+      align-items: center;
+      padding: 9px 14px;
+      border-radius: 999px;
+      background: var(--sage);
+      font-weight: 750;
+      font-size: 14px;
+    }
+    .status::before { content: ""; width: 9px; height: 9px; border-radius: 50%; background: #4c7a54; }
+    nav { display: flex; flex-wrap: wrap; gap: 10px; margin: 22px 0 0; }
+    nav a {
+      color: var(--ink);
+      text-decoration: none;
+      padding: 8px 13px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      background: rgba(255,255,255,.7);
+      font-size: 14px;
+    }
+    section { margin-top: 72px; scroll-margin-top: 24px; }
+    .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 18px; }
+    .card {
+      grid-column: span 4;
+      padding: 25px;
+      border: 1px solid var(--line);
+      border-radius: 22px;
+      background: rgba(255,255,255,.86);
+      box-shadow: 0 10px 30px rgba(75,48,38,.04);
+    }
+    .card.wide { grid-column: span 6; }
+    .card.full { grid-column: 1 / -1; }
+    .card p:last-child, .callout p:last-child { margin-bottom: 0; }
+    .number {
+      width: 36px; height: 36px; border-radius: 50%;
+      display: grid; place-items: center; margin-bottom: 16px;
+      color: #fff; background: var(--coral); font-weight: 800;
+    }
+    .callout {
+      padding: 26px;
+      border-left: 5px solid var(--coral);
+      border-radius: 8px 22px 22px 8px;
+      background: var(--rose);
+    }
+    .boundary {
+      padding: 24px;
+      border: 1px solid #d0dfd0;
+      border-radius: 22px;
+      background: var(--sage);
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: rgba(255,255,255,.9);
+    }
+    th, td { padding: 16px 18px; text-align: left; vertical-align: top; border-bottom: 1px solid var(--line); }
+    th { color: var(--muted); background: #fbf4ed; font-size: 12px; letter-spacing: .08em; text-transform: uppercase; }
+    tr:last-child td { border-bottom: 0; }
+    code {
+      padding: 2px 6px;
+      border-radius: 6px;
+      background: #f4ece6;
+      font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+    }
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 10px;
+      align-items: stretch;
+    }
+    .flow div {
+      position: relative;
+      min-height: 116px;
+      padding: 18px;
+      border-radius: 17px;
+      background: var(--card);
+      border: 1px solid var(--line);
+      font-size: 14px;
+    }
+    .flow div:not(:last-child)::after {
+      content: "→";
+      position: absolute;
+      right: -11px;
+      top: 42%;
+      z-index: 2;
+      color: var(--coral);
+      font-size: 19px;
+      font-weight: 900;
+    }
+    .flow strong { display: block; margin-bottom: 6px; font-size: 15px; }
+    .pass, .hold { display: inline-block; padding: 4px 9px; border-radius: 999px; font-size: 12px; font-weight: 800; }
+    .pass { color: #315b39; background: var(--sage); }
+    .hold { color: #705317; background: var(--amber); }
+    ul { margin: 10px 0 0; padding-left: 21px; }
+    li { margin: 7px 0; }
+    .claim-safe { border-top: 4px solid #5f8a65; }
+    .claim-hold { border-top: 4px solid #c39038; }
+    footer { margin-top: 72px; padding: 24px 0; color: var(--muted); border-top: 1px solid var(--line); font-size: 14px; }
+    @media (max-width: 820px) {
+      .card, .card.wide { grid-column: 1 / -1; }
+      .flow { grid-template-columns: 1fr; }
+      .flow div:not(:last-child)::after { content: "↓"; right: 50%; top: auto; bottom: -19px; }
+      table { display: block; overflow-x: auto; }
+    }
+    @media print {
+      body { background: #fff; }
+      main { width: 100%; padding: 0; }
+      header, .card { box-shadow: none; }
+      section { break-inside: avoid; margin-top: 40px; }
+      nav { display: none; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <div class="eyebrow">Our Little World · controlled release convergence · 24 July 2026</div>
+    <h1>Account deletion is now a real product flow—not a policy promise.</h1>
+    <p class="lead">Parents can export first, see exactly what their family role means, reauthenticate, and permanently remove their account without erasing a co-parent’s family history or touching the camera roll.</p>
+    <div class="status">Implementation and local runtime proof complete</div>
+    <nav aria-label="Report sections">
+      <a href="#experience">Parent experience</a>
+      <a href="#roles">Role outcomes</a>
+      <a href="#privacy">Privacy boundary</a>
+      <a href="#architecture">How it works</a>
+      <a href="#proof">Evidence</a>
+      <a href="#release">Release boundary</a>
+      <a href="#marketing">Marketing claims</a>
+    </nav>
+  </header>
+
+  <section id="experience">
+    <div class="eyebrow">The parent experience</div>
+    <h2>Clear enough to trust. Deliberate enough to prevent accidents.</h2>
+    <div class="grid">
+      <article class="card"><div class="number">1</div><h3>Reachable account controls</h3><p>Delete account is available from normal settings and remains reachable during incomplete setup, no-family onboarding, lapsed/read-only access, and the purchase gate.</p></article>
+      <article class="card"><div class="number">2</div><h3>Export before deletion</h3><p>The first action opens the current family export, discloses its current video, audio, and sharing limits, and tells a parent with multiple sole-parent archives to export each one they want to keep.</p></article>
+      <article class="card"><div class="number">3</div><h3>Exact impact, not generic fear</h3><p>The server counts sole-writer, shared-writer, and Circle memberships. If that preview cannot load, deletion cannot advance.</p></article>
+      <article class="card"><div class="number">4</div><h3>Fresh reauthentication</h3><p>A six-digit code is sent to the current account email. The backend consumes it directly with Supabase Auth and verifies that it resolves to the same user.</p></article>
+      <article class="card"><div class="number">5</div><h3>Explicit final act</h3><p>The parent must enter the fresh code and type <code>DELETE</code> exactly. The destructive button stays disabled until both checks are satisfied.</p></article>
+      <article class="card"><div class="number">6</div><h3>Device cleanup and honest completion</h3><p>Private queues, drafts, caches, scheduled notifications, and the local session are cleared. A partial local cleanup tells the parent to reinstall before another sign-in.</p></article>
+    </div>
+  </section>
+
+  <section id="roles">
+    <div class="eyebrow">Role-aware ownership</div>
+    <h2>“Delete me” does not mean “delete everybody.”</h2>
+    <table>
+      <thead><tr><th>Requester state</th><th>Deleted</th><th>Preserved</th><th>Billing behavior</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Sole writer</strong></td><td>Family rows, app-controlled Supabase Storage, Stream video, R2 originals, user/device state, membership, Auth account.</td><td>Minimum detached billing/legal evidence; device camera roll; explicit export.</td><td>Active Stripe subscription is canceled first. Store subscription requires the parent’s store action.</td></tr>
+        <tr><td><strong>Additional writer</strong></td><td>Requester membership, push/notification/device state, private local ledgers and drafts, Auth account.</td><td>Shared family archive, media, collections, context, other writer membership, separately authored records with null attribution.</td><td>Deleted user is detached from retained billing records; remaining family/provider state is not invented or reassigned.</td></tr>
+        <tr><td><strong>Circle member</strong></td><td>Read-only membership, requester notifications/push state, Auth account.</td><td>The entire family archive, media, billing, gifts, Firsts, letters, and writer data.</td><td>No family billing ownership is removed from Circle.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section id="privacy">
+    <div class="eyebrow">Trust contract</div>
+    <h2>The deletion system sees less than the product sees.</h2>
+    <div class="boundary">
+      <h3>Never leaves the parent’s device before Keep</h3>
+      <p>Unsaved candidates, Photos asset IDs, face evidence, fingerprints, selection rationale, rejects, unavailable originals, Tonight queue state, text drafts, and temporary voice paths are not inputs to the Edge function, audit ledger, provider cleanup, analytics, notifications, reports, or another caregiver’s device.</p>
+    </div>
+    <div class="grid" style="margin-top:18px">
+      <article class="card wide"><h3>Service-only audit</h3><p>The durable ledger contains request and family-role identifiers, timestamps, status, attempt/error code, legal-hold state, and aggregate provider counts. It has no public/authenticated policy and no content or paths.</p></article>
+      <article class="card wide"><h3>Fail-closed mutation window</h3><p>A family lock makes established writer checks false and blocks membership changes between inventory and finalization. If the lock expires or a role changes, finalization stops and re-inventories.</p></article>
+      <article class="card wide"><h3>Legal hold before providers</h3><p>A hold stops the request before any Storage, Stream, R2, Stripe, database, or Auth deletion begins.</p></article>
+      <article class="card wide"><h3>No deletion analytics</h3><p>The mobile flow sends no deletion event. Provider and release evidence stays aggregate and never contains account content, email codes, media identifiers, or family examples.</p></article>
+      <article class="card full"><h3>Old media sessions fail closed</h3><p>The R2 Worker writes a content-free family deletion marker before erasure and checks it before original-media cache lookup. A still-valid short-lived token therefore receives <code>410</code> instead of a stale cached original.</p></article>
+    </div>
+  </section>
+
+  <section id="architecture">
+    <div class="eyebrow">Technical architecture</div>
+    <h2>One resumable transaction across five systems.</h2>
+    <div class="flow" aria-label="Account deletion lifecycle">
+      <div><strong>1. Mobile</strong>Export, server preview, OTP, exact confirmation.</div>
+      <div><strong>2. Supabase DB</strong>Audit row, legal hold, role inventory, family locks.</div>
+      <div><strong>3. Providers</strong>Storage prefix, Stream UID + family metadata, R2 prefix, Stripe.</div>
+      <div><strong>4. Finalizer</strong>Delete sole families; remove shared/Circle membership; minimize retained records.</div>
+      <div><strong>5. Auth + device</strong>Hard-delete user; clear SQLite, AsyncStorage, drafts, notifications, session.</div>
+    </div>
+    <div class="callout" style="margin-top:22px">
+      <h3>Why these technologies</h3>
+      <p><strong>Expo/React Native</strong> keeps the account journey inside the shipped family app and can erase native SQLite, files, notifications, and secure auth state. <strong>Supabase Postgres/RLS</strong> owns family roles, lifecycle locks, cascades, nullable authorship, and service-only audit. <strong>Deno Edge Functions</strong> provide the admin-only orchestration boundary without shipping credentials. <strong>Cloudflare Stream and R2</strong> hold video/original media, so their deletion must be verified before the family rows disappear. <strong>Wrangler</strong> validates that Worker code and bindings bundle without mutating production.</p>
+    </div>
+  </section>
+
+  <section id="proof">
+    <div class="eyebrow">Evidence completed</div>
+    <h2>Proven with synthetic accounts and real local service boundaries.</h2>
+    <div class="grid">
+      <article class="card"><span class="pass">PASS</span><h3>Fresh schema replay</h3><p>Every migration replayed on a disposable local database; schema lint passed. The account migration was reapplied twice to prove restart safety.</p></article>
+      <article class="card"><span class="pass">39 / 39</span><h3>Lifecycle pgTAP</h3><p>Role classification, locks, legal hold, cross-family selection, shared preservation, billing minimization, Auth deletion, and idempotency.</p></article>
+      <article class="card"><span class="pass">133 / 133</span><h3>Repository SQL contracts</h3><p>Account deletion plus existing Circle, shared-authorship, collections, and grounded-context contracts all passed.</p></article>
+      <article class="card"><span class="pass">10 / 10</span><h3>Edge and Worker tests</h3><p>Explicit confirmation, OTP normalization, family prefixes, aggregate-only evidence, authenticated R2 deletion, and deleted-session cache denial.</p></article>
+      <article class="card"><span class="pass">448 / 448</span><h3>Mobile contracts</h3><p>The complete mobile unit suite, repository lint/typecheck/build, Expo lint, and Expo Doctor 20/20 passed.</p></article>
+      <article class="card"><span class="pass">LOCAL E2E</span><h3>Actual Auth + OTP + Storage</h3><p>Synthetic two-writer and sole-family records went through local Auth, Mailpit OTP, Edge HTTP, PostgREST, Storage, database finalization, and hard user deletion.</p></article>
+      <article class="card"><span class="pass">DRY RUN</span><h3>Media Worker bundle</h3><p>Current Wrangler bundled the R2-bound Worker and inspected startup without deployment.</p></article>
+    </div>
+    <div class="callout" style="margin-top:22px">
+      <p><strong>Observed result:</strong> the sole family and its Storage object were gone; the shared family, remaining writer, shared moment, and shared Storage object remained; the deleting writer’s membership disappeared; shared attribution became null; the Supabase Auth user returned not found.</p>
+    </div>
+  </section>
+
+  <section id="release">
+    <div class="eyebrow">Controlled release boundary</div>
+    <h2>Ready for review and non-production provider rehearsal—not silently deployed.</h2>
+    <div class="grid">
+      <article class="card wide">
+        <span class="pass">COMPLETE LOCALLY</span>
+        <h3>Source and deterministic proof</h3>
+        <p>Implemented on isolated branch <code>codex/olw-account-deletion</code> from clean release base <code>5560b74</code> in commits <code>dba9fb2</code>, <code>5588ff7</code>, and <code>82d8282</code>, without incorporating the unrelated dirty canonical checkout.</p>
+      </article>
+      <article class="card wide">
+        <span class="hold">AUTHORIZATION REQUIRED</span>
+        <h3>Production and signed release</h3>
+        <p>Production migration, secret creation/change, Worker/Edge deployment, internal signed build upload, physical-device deletion, and public store promotion remain separate actions.</p>
+      </article>
+      <article class="card full">
+        <h3>Current provider and signed-build truth</h3>
+        <p>The linked Supabase project has no preview branch. Production has the earlier <code>create-stream-upload</code> but no <code>delete-account</code>; the deployed media Worker predates this implementation. The latest EAS store artifact is iOS <code>1.1.0</code> build <code>1.1.11</code> from base commit <code>5560b74</code>, so no signed build currently contains this flow. The deterministic smoke passed 25/25 before Maestro stopped at the absent authorized local test-code profile.</p>
+      </article>
+      <article class="card full">
+        <h3>Authorized order when Jesse approves it</h3>
+        <p>Additive migration → verify grants/RLS → configure the shared Worker/Edge deletion secret → deploy media Worker → deploy Stream tracking and deletion Edge functions → provider-backed synthetic rehearsal → clean signed client → physical-device synthetic deletion → limited cohort → aggregate monitoring.</p>
+      </article>
+    </div>
+  </section>
+
+  <section id="marketing">
+    <div class="eyebrow">Marketing truth</div>
+    <h2>The product promise this unlocks—after release evidence exists.</h2>
+    <div class="grid">
+      <article class="card wide claim-safe">
+        <h3>Claims supported by the implemented behavior</h3>
+        <ul>
+          <li>Your camera roll stays yours; deleting Our Little World does not delete device originals.</li>
+          <li>You can export your parent-approved archive before deleting the account.</li>
+          <li>Leaving a shared family does not erase the other parent’s family history.</li>
+          <li>Private discovery work and drafts stay on the parent’s device and are cleared with the deleted account.</li>
+        </ul>
+      </article>
+      <article class="card wide claim-hold">
+        <h3>Withhold from public claims until deployed and signed-device verified</h3>
+        <ul>
+          <li>“Delete your account in the app” as a currently available store-build capability.</li>
+          <li>Complete Stream/R2/Stripe erasure in the production provider configuration.</li>
+          <li>Any promise of instantaneous backup/log expiry or deletion beyond app-controlled systems.</li>
+          <li>Any claim that Apple or Google subscriptions are canceled by account deletion.</li>
+        </ul>
+      </article>
+    </div>
+  </section>
+
+  <footer>
+    Source companions: <code>docs/account-deletion-implementation.md</code>,
+    <code>docs/account-deletion-policy.md</code>, and
+    <code>docs/account-deletion-operations.md</code>. This report contains no real
+    family data, account identifiers, OTPs, media examples, provider secrets, or
+    private recognition evidence.
+  </footer>
+</main>
+</body>
+</html>

--- a/scripts/qa-account-deletion-local.mjs
+++ b/scripts/qa-account-deletion-local.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { randomBytes, randomUUID } from 'node:crypto';
+
+const status = parseEnv(execFileSync('supabase', ['status', '-o', 'env'], {
+  encoding: 'utf8',
+  stdio: ['ignore', 'pipe', 'ignore'],
+}));
+const apiUrl = required(status, 'API_URL');
+const restUrl = required(status, 'REST_URL');
+const functionsUrl = required(status, 'FUNCTIONS_URL');
+const mailpitUrl = required(status, 'MAILPIT_URL');
+const anonKey = required(status, 'ANON_KEY');
+const serviceRoleKey = required(status, 'SERVICE_ROLE_KEY');
+
+if (!/^https?:\/\/(127\.0\.0\.1|localhost)(:\d+)?\//.test(`${apiUrl}/`)) {
+  throw new Error('Account deletion QA is local-only and refused a non-local Supabase URL.');
+}
+
+const runToken = randomBytes(6).toString('hex');
+const targetEmail = `delete-target-${runToken}@example.test`;
+const remainingEmail = `delete-remaining-${runToken}@example.test`;
+const password = `Local-only-${randomBytes(18).toString('base64url')}!`;
+const soleFamilyId = randomUUID();
+const sharedFamilyId = randomUUID();
+const sharedMomentId = randomUUID();
+const soleObjectPath = `${soleFamilyId}/synthetic/deletion-proof.txt`;
+const sharedObjectPath = `${sharedFamilyId}/synthetic/preserved-proof.txt`;
+const created = {
+  targetUserId: null,
+  remainingUserId: null,
+};
+
+try {
+  created.targetUserId = (await authAdmin('/users', {
+    method: 'POST',
+    body: { email: targetEmail, password, email_confirm: true },
+  })).id;
+  created.remainingUserId = (await authAdmin('/users', {
+    method: 'POST',
+    body: { email: remainingEmail, password, email_confirm: true },
+  })).id;
+
+  await restInsert('families', [
+    { id: soleFamilyId, name: 'Synthetic sole family', baby_name: 'Synthetic', created_by: created.targetUserId },
+    { id: sharedFamilyId, name: 'Synthetic shared family', baby_name: 'Synthetic', created_by: created.remainingUserId },
+  ]);
+  await restInsert('family_members', [
+    { family_id: soleFamilyId, user_id: created.targetUserId, display_name: 'Target', role: 'creator' },
+    { family_id: sharedFamilyId, user_id: created.targetUserId, display_name: 'Target', role: 'partner' },
+    { family_id: sharedFamilyId, user_id: created.remainingUserId, display_name: 'Remaining', role: 'creator' },
+  ]);
+  await restInsert('family_entitlements', [
+    { family_id: soleFamilyId, status: 'active', source: 'admin', plan_key: 'comp_year' },
+    { family_id: sharedFamilyId, status: 'active', source: 'admin', plan_key: 'comp_year' },
+  ]);
+  await restInsert('moments', [{
+    id: sharedMomentId,
+    family_id: sharedFamilyId,
+    author_user_id: created.targetUserId,
+    title: 'Synthetic shared deletion proof',
+    captured_at: new Date().toISOString(),
+  }]);
+  await uploadObject(soleObjectPath, 'synthetic sole-family object');
+  await uploadObject(sharedObjectPath, 'synthetic shared-family object');
+
+  const session = await authPublic('/token?grant_type=password', {
+    method: 'POST',
+    body: { email: targetEmail, password },
+  });
+  const preview = await invokeDeletion(session.access_token, { action: 'preview' });
+  assert(preview?.preview?.soleWriterCount === 1, 'preview did not identify the sole-writer family');
+  assert(preview?.preview?.additionalWriterCount === 1, 'preview did not identify the shared-writer family');
+
+  const otpRequestedAt = Date.now();
+  await authPublic('/otp', {
+    method: 'POST',
+    body: { email: targetEmail, create_user: false },
+  });
+  const otp = await waitForOtp(targetEmail, otpRequestedAt);
+  const deleted = await invokeDeletion(session.access_token, {
+    action: 'delete',
+    requestId: randomUUID(),
+    email: targetEmail,
+    otp,
+    confirmation: 'DELETE',
+  });
+  assert(deleted?.completed === true, 'Edge deletion did not report completion');
+
+  const soleFamilies = await restSelect('families', `id=eq.${soleFamilyId}&select=id`);
+  const sharedFamilies = await restSelect('families', `id=eq.${sharedFamilyId}&select=id`);
+  const remainingMembership = await restSelect(
+    'family_members',
+    `family_id=eq.${sharedFamilyId}&user_id=eq.${created.remainingUserId}&select=user_id`,
+  );
+  const targetMemberships = await restSelect(
+    'family_members',
+    `user_id=eq.${created.targetUserId}&select=user_id`,
+  );
+  const sharedMoments = await restSelect(
+    'moments',
+    `id=eq.${sharedMomentId}&select=id,author_user_id`,
+  );
+  const targetAuthStatus = await authAdminStatus(created.targetUserId);
+  const soleObjectStatus = await objectStatus(soleObjectPath);
+  const sharedObjectStatus = await objectStatus(sharedObjectPath);
+
+  assert(soleFamilies.length === 0, 'sole-writer family remained');
+  assert(sharedFamilies.length === 1, 'shared family was removed');
+  assert(remainingMembership.length === 1, 'remaining writer membership was removed');
+  assert(targetMemberships.length === 0, 'deleted user membership remained');
+  assert(sharedMoments.length === 1 && sharedMoments[0].author_user_id === null, 'shared authorship was not preserved anonymously');
+  assert(targetAuthStatus === 404, 'authentication account remained');
+  assert(soleObjectStatus !== 200, 'sole-family Storage object remained');
+  assert(sharedObjectStatus === 200, 'shared-family Storage object was removed');
+
+  console.log(JSON.stringify({
+    gate: 'account_deletion_local_e2e',
+    result: 'pass',
+    roleCounts: { soleWriter: 1, additionalWriter: 1 },
+    authDeleted: true,
+    soleFamilyDeleted: true,
+    sharedFamilyPreserved: true,
+    sharedAuthorshipAnonymized: true,
+    soleStorageDeleted: true,
+    sharedStoragePreserved: true,
+  }));
+} finally {
+  await deleteObject(soleObjectPath).catch(() => undefined);
+  await deleteObject(sharedObjectPath).catch(() => undefined);
+  await deleteRest('families', `id=eq.${sharedFamilyId}`).catch(() => undefined);
+  if (created.targetUserId) await authAdmin(`/users/${created.targetUserId}`, { method: 'DELETE' }).catch(() => undefined);
+  if (created.remainingUserId) await authAdmin(`/users/${created.remainingUserId}`, { method: 'DELETE' }).catch(() => undefined);
+}
+
+async function invokeDeletion(accessToken, body) {
+  return requestJson(`${functionsUrl}/delete-account`, {
+    method: 'POST',
+    headers: {
+      apikey: anonKey,
+      authorization: `Bearer ${accessToken}`,
+    },
+    body,
+  });
+}
+
+async function authPublic(path, init) {
+  return requestJson(`${apiUrl}/auth/v1${path}`, {
+    ...init,
+    headers: { apikey: anonKey },
+  });
+}
+
+async function authAdmin(path, init) {
+  return requestJson(`${apiUrl}/auth/v1/admin${path}`, {
+    ...init,
+    headers: {
+      apikey: serviceRoleKey,
+      authorization: `Bearer ${serviceRoleKey}`,
+    },
+  });
+}
+
+async function authAdminStatus(userId) {
+  const response = await fetch(`${apiUrl}/auth/v1/admin/users/${encodeURIComponent(userId)}`, {
+    headers: {
+      apikey: serviceRoleKey,
+      authorization: `Bearer ${serviceRoleKey}`,
+    },
+  });
+  return response.status;
+}
+
+async function restInsert(table, rows) {
+  return requestJson(`${restUrl}/${table}`, {
+    method: 'POST',
+    headers: serviceHeaders({ Prefer: 'return=minimal' }),
+    body: rows,
+    allowEmpty: true,
+  });
+}
+
+async function restSelect(table, query) {
+  return requestJson(`${restUrl}/${table}?${query}`, {
+    headers: serviceHeaders(),
+  });
+}
+
+async function deleteRest(table, query) {
+  return requestJson(`${restUrl}/${table}?${query}`, {
+    method: 'DELETE',
+    headers: serviceHeaders({ Prefer: 'return=minimal' }),
+    allowEmpty: true,
+  });
+}
+
+async function uploadObject(path, content) {
+  const response = await fetch(`${apiUrl}/storage/v1/object/family-photos/${path}`, {
+    method: 'POST',
+    headers: {
+      apikey: serviceRoleKey,
+      authorization: `Bearer ${serviceRoleKey}`,
+      'content-type': 'text/plain',
+      'x-upsert': 'false',
+    },
+    body: content,
+  });
+  if (!response.ok) throw new Error(`Synthetic Storage upload failed (${response.status}).`);
+}
+
+async function objectStatus(path) {
+  const response = await fetch(`${apiUrl}/storage/v1/object/authenticated/family-photos/${path}`, {
+    headers: {
+      apikey: serviceRoleKey,
+      authorization: `Bearer ${serviceRoleKey}`,
+    },
+  });
+  return response.status;
+}
+
+async function deleteObject(path) {
+  const response = await fetch(`${apiUrl}/storage/v1/object/family-photos/${path}`, {
+    method: 'DELETE',
+    headers: {
+      apikey: serviceRoleKey,
+      authorization: `Bearer ${serviceRoleKey}`,
+    },
+  });
+  if (!response.ok && response.status !== 400 && response.status !== 404) {
+    throw new Error(`Synthetic Storage cleanup failed (${response.status}).`);
+  }
+}
+
+async function waitForOtp(email, requestedAt) {
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline) {
+    const listing = await requestJson(`${mailpitUrl}/api/v1/messages?limit=50`);
+    const candidate = (listing?.messages || []).find((message) =>
+      new Date(message.Created || 0).getTime() >= requestedAt - 2000
+      && (message.To || []).some((recipient) =>
+        String(recipient.Address || recipient).toLowerCase() === email.toLowerCase()
+      )
+    );
+    if (candidate?.ID) {
+      const message = await requestJson(`${mailpitUrl}/api/v1/message/${candidate.ID}`);
+      const content = `${message?.Text || ''}\n${message?.HTML || ''}`;
+      const match = content.match(/(?:token|code)[^0-9]{0,80}(\d{6})/i)
+        || content.match(/\b(\d{6})\b/);
+      if (match) return match[1];
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error('Synthetic deletion OTP did not arrive in local Mailpit.');
+}
+
+async function requestJson(url, {
+  method = 'GET',
+  headers = {},
+  body,
+  allowEmpty = false,
+} = {}) {
+  const response = await fetch(url, {
+    method,
+    headers: {
+      accept: 'application/json',
+      ...(body === undefined ? {} : { 'content-type': 'application/json' }),
+      ...headers,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    throw new Error(`Local QA request failed at ${new URL(url).pathname} (${response.status}): ${payload?.error || payload?.message || 'unknown error'}`);
+  }
+  if (!text && !allowEmpty) return null;
+  return payload;
+}
+
+function serviceHeaders(extra = {}) {
+  return {
+    apikey: serviceRoleKey,
+    authorization: `Bearer ${serviceRoleKey}`,
+    ...extra,
+  };
+}
+
+function parseEnv(output) {
+  return Object.fromEntries(String(output).split(/\r?\n/).flatMap((line) => {
+    const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+    if (!match) return [];
+    const value = match[2].replace(/^"(.*)"$/, '$1');
+    return [[match[1], value]];
+  }));
+}
+
+function required(values, key) {
+  if (!values[key]) throw new Error(`Local Supabase status did not include ${key}.`);
+  return values[key];
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}

--- a/supabase/functions/_shared/accountDeletion.ts
+++ b/supabase/functions/_shared/accountDeletion.ts
@@ -1,0 +1,113 @@
+export const ACCOUNT_DELETION_CONFIRMATION = 'DELETE';
+export const ACCOUNT_DELETION_STORAGE_BUCKET = 'family-photos';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const STREAM_UID_PATTERN = /^[A-Za-z0-9_-]{6,128}$/;
+const PROVIDER_OBJECT_PATTERN = /^[A-Za-z0-9._-]{1,160}$/;
+
+export function isUuid(value: unknown): value is string {
+  return UUID_PATTERN.test(String(value || ''));
+}
+
+export function requireDeletionConfirmation(value: unknown) {
+  if (String(value || '').trim() !== ACCOUNT_DELETION_CONFIRMATION) {
+    throw new Error('Type DELETE to confirm account deletion.');
+  }
+}
+
+export function normalizeOtp(value: unknown) {
+  const token = String(value || '').replace(/\s/g, '');
+  return /^\d{6}$/.test(token) ? token : null;
+}
+
+export function normalizeEmail(value: unknown) {
+  return String(value || '').trim().toLowerCase();
+}
+
+export function normalizeFamilyIds(values: unknown) {
+  return uniqueStrings(values).filter(isUuid);
+}
+
+export function normalizeStreamUids(values: unknown) {
+  return uniqueStrings(values).filter((value) => STREAM_UID_PATTERN.test(value));
+}
+
+export function normalizeProviderObjectIds(values: unknown) {
+  return uniqueStrings(values).filter((value) => PROVIDER_OBJECT_PATTERN.test(value));
+}
+
+export function normalizeFamilyStoragePaths(familyId: string, values: unknown) {
+  if (!isUuid(familyId)) return [];
+  const prefix = `${familyId}/`;
+  return uniqueStrings(values)
+    .map((value) => value.replace(/^\/+/, ''))
+    .filter((value) => value.startsWith(prefix))
+    .filter((value) => !value.includes('..'))
+    .filter((value) => value.length <= 1024);
+}
+
+export function storageListingEntryPath(prefix: string, entry: Record<string, unknown>) {
+  const name = String(entry?.name || '').replace(/^\/+|\/+$/g, '');
+  if (!name || name === '.' || name === '..' || name.includes('/../')) return null;
+  return `${String(prefix || '').replace(/\/+$/g, '')}/${name}`.replace(/^\/+/, '');
+}
+
+export function splitStorageListing(
+  familyId: string,
+  prefix: string,
+  entries: Array<Record<string, unknown>> = [],
+) {
+  const files: string[] = [];
+  const folders: string[] = [];
+  for (const entry of entries) {
+    const path = storageListingEntryPath(prefix, entry);
+    if (!path || !normalizeFamilyStoragePaths(familyId, [path]).length) continue;
+    const isFolder = !entry.id && !entry.metadata;
+    if (isFolder) folders.push(path);
+    else files.push(path);
+  }
+  return {
+    files: [...new Set(files)].sort(),
+    folders: [...new Set(folders)].sort(),
+  };
+}
+
+export function publicDeletionPreview(value: Record<string, unknown> | null | undefined) {
+  return {
+    familyCount: nonNegativeInteger(value?.family_count),
+    soleWriterCount: nonNegativeInteger(value?.sole_writer_count),
+    additionalWriterCount: nonNegativeInteger(value?.additional_writer_count),
+    circleCount: nonNegativeInteger(value?.circle_count),
+    storeSubscriptionActionRequired: Boolean(value?.store_subscription_action_required),
+    stripeCancellationRequired: Boolean(value?.stripe_cancellation_required),
+  };
+}
+
+export function providerCleanupSummary({
+  storageDeleted = 0,
+  streamDeleted = 0,
+  r2DeleteRequests = 0,
+  stripeCanceled = 0,
+}: {
+  storageDeleted?: number;
+  streamDeleted?: number;
+  r2DeleteRequests?: number;
+  stripeCanceled?: number;
+} = {}) {
+  return {
+    storage_deleted_count: nonNegativeInteger(storageDeleted),
+    stream_deleted_count: nonNegativeInteger(streamDeleted),
+    r2_delete_request_count: nonNegativeInteger(r2DeleteRequests),
+    stripe_canceled_count: nonNegativeInteger(stripeCanceled),
+  };
+}
+
+function uniqueStrings(values: unknown) {
+  if (!Array.isArray(values)) return [];
+  return [...new Set(values.map((value) => String(value || '').trim()).filter(Boolean))];
+}
+
+function nonNegativeInteger(value: unknown) {
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.max(0, Math.floor(number)) : 0;
+}

--- a/supabase/functions/_shared/accountDeletion_test.ts
+++ b/supabase/functions/_shared/accountDeletion_test.ts
@@ -1,0 +1,93 @@
+import {
+  assertEquals,
+  assertThrows,
+} from 'jsr:@std/assert@1';
+
+import {
+  normalizeFamilyIds,
+  normalizeFamilyStoragePaths,
+  normalizeOtp,
+  normalizeProviderObjectIds,
+  normalizeStreamUids,
+  providerCleanupSummary,
+  publicDeletionPreview,
+  requireDeletionConfirmation,
+  splitStorageListing,
+} from './accountDeletion.ts';
+
+const FAMILY_ID = '10000000-0000-4000-8000-000000000001';
+const OTHER_FAMILY_ID = '20000000-0000-4000-8000-000000000002';
+
+Deno.test('account deletion confirmation is exact and explicit', () => {
+  requireDeletionConfirmation('DELETE');
+  assertThrows(() => requireDeletionConfirmation('delete'));
+  assertThrows(() => requireDeletionConfirmation('DELETE MY PHOTOS'));
+});
+
+Deno.test('OTP normalization accepts only a six digit email code', () => {
+  assertEquals(normalizeOtp('123 456'), '123456');
+  assertEquals(normalizeOtp('12345'), null);
+  assertEquals(normalizeOtp('12345a'), null);
+});
+
+Deno.test('storage selection cannot cross the target family prefix', () => {
+  assertEquals(
+    normalizeFamilyStoragePaths(FAMILY_ID, [
+      `${FAMILY_ID}/moments/a/image-full/file.jpg`,
+      `${OTHER_FAMILY_ID}/moments/b/image-full/private.jpg`,
+      `${FAMILY_ID}/../${OTHER_FAMILY_ID}/private.jpg`,
+      '/not-a-family/file.jpg',
+    ]),
+    [`${FAMILY_ID}/moments/a/image-full/file.jpg`],
+  );
+});
+
+Deno.test('recursive storage listing separates folders and files inside one family', () => {
+  assertEquals(
+    splitStorageListing(FAMILY_ID, FAMILY_ID, [
+      { name: 'moments', id: null, metadata: null },
+      { name: 'legacy.jpg', id: 'storage-id', metadata: { size: 10 } },
+      { name: `../${OTHER_FAMILY_ID}`, id: null, metadata: null },
+    ]),
+    {
+      files: [`${FAMILY_ID}/legacy.jpg`],
+      folders: [`${FAMILY_ID}/moments`],
+    },
+  );
+});
+
+Deno.test('provider identifiers are bounded and deduplicated', () => {
+  assertEquals(normalizeFamilyIds([FAMILY_ID, FAMILY_ID, 'bad']), [FAMILY_ID]);
+  assertEquals(normalizeStreamUids(['abc12345', 'abc12345', '../bad']), ['abc12345']);
+  assertEquals(normalizeProviderObjectIds(['safe-object_1', 'safe-object_1', '../bad']), ['safe-object_1']);
+});
+
+Deno.test('public preview and provider audit summary contain aggregate values only', () => {
+  assertEquals(publicDeletionPreview({
+    family_count: 2,
+    sole_writer_count: 1,
+    additional_writer_count: 1,
+    circle_count: 0,
+    store_subscription_action_required: true,
+    stripe_cancellation_required: false,
+    family_id: FAMILY_ID,
+  }), {
+    familyCount: 2,
+    soleWriterCount: 1,
+    additionalWriterCount: 1,
+    circleCount: 0,
+    storeSubscriptionActionRequired: true,
+    stripeCancellationRequired: false,
+  });
+  assertEquals(providerCleanupSummary({
+    storageDeleted: 4.9,
+    streamDeleted: -2,
+    r2DeleteRequests: 1,
+    stripeCanceled: 1,
+  }), {
+    storage_deleted_count: 4,
+    stream_deleted_count: 0,
+    r2_delete_request_count: 1,
+    stripe_canceled_count: 1,
+  });
+});

--- a/supabase/functions/create-stream-upload/index.ts
+++ b/supabase/functions/create-stream-upload/index.ts
@@ -68,6 +68,27 @@ Deno.serve(async (req) => {
       throw new HttpError(502, payload?.errors?.[0]?.message || 'Stream upload could not be prepared.');
     }
 
+    try {
+      // Persist the provider UID before returning the upload URL. If the app
+      // terminates before moment_media is finalized, account deletion can
+      // still find and remove the orphaned Stream upload.
+      await rpc('attach_media_upload_provider_object', {
+        p_reservation_id: row.reservation_id,
+        p_provider: 'stream',
+        p_provider_object_id: payload.result.uid,
+      }, token);
+    } catch {
+      await fetch(
+        `https://api.cloudflare.com/client/v4/accounts/${accountId}/stream/${encodeURIComponent(payload.result.uid)}`,
+        {
+          method: 'DELETE',
+          headers: { authorization: `Bearer ${apiToken}` },
+        },
+      ).catch(() => undefined);
+      await rpc('release_media_upload', { p_reservation_id: row.reservation_id }, token).catch(() => undefined);
+      throw new HttpError(502, 'Stream upload could not be recorded safely.');
+    }
+
     return json({
       uploadURL: payload.result.uploadURL,
       uid: payload.result.uid,

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,428 @@
+import {
+  HttpError,
+  corsHeaders,
+  env,
+  json,
+  readJson,
+  requiredEnv,
+  requireUser,
+  rpc,
+  supabaseRequest,
+} from '../_shared/billing.ts';
+import {
+  ACCOUNT_DELETION_STORAGE_BUCKET,
+  isUuid,
+  normalizeEmail,
+  normalizeFamilyIds,
+  normalizeFamilyStoragePaths,
+  normalizeOtp,
+  normalizeProviderObjectIds,
+  normalizeStreamUids,
+  providerCleanupSummary,
+  publicDeletionPreview,
+  requireDeletionConfirmation,
+  splitStorageListing,
+} from '../_shared/accountDeletion.ts';
+
+class DeletionError extends HttpError {
+  code: string;
+
+  constructor(status: number, code: string, message: string) {
+    super(status, message);
+    this.code = code;
+  }
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: corsHeaders });
+  if (req.method !== 'POST') return json({ error: 'Method not allowed.' }, 405);
+
+  let requestId: string | null = null;
+  let userId: string | null = null;
+  let cleanupSummary = providerCleanupSummary();
+
+  try {
+    const { user } = await requireUser(req);
+    userId = user.id;
+    const body = await readJson(req);
+    const action = String(body.action || 'delete').trim().toLowerCase();
+
+    if (action === 'preview') {
+      const preview = await rpc('preview_account_deletion', { target_user_id: user.id });
+      return json({ preview: publicDeletionPreview(asRecord(preview)) });
+    }
+    if (action !== 'delete') throw new DeletionError(400, 'invalid_action', 'Deletion action is invalid.');
+
+    requireDeletionConfirmation(body.confirmation);
+    const proposedRequestId = String(body.requestId || body.request_id || '').trim();
+    if (!isUuid(proposedRequestId)) {
+      throw new DeletionError(400, 'invalid_request_id', 'Deletion request is invalid.');
+    }
+
+    const email = normalizeEmail(body.email);
+    const otp = normalizeOtp(body.otp);
+    if (!email || email !== normalizeEmail(user.email) || !otp) {
+      throw new DeletionError(401, 'reauthentication_required', 'Enter the fresh code sent to your account email.');
+    }
+    await verifyDeletionOtp({ email, otp, expectedUserId: user.id });
+
+    const started = asRecord(await rpc('begin_account_deletion', {
+      target_user_id: user.id,
+      proposed_request_id: proposedRequestId,
+      reauthenticated_at: new Date().toISOString(),
+    }));
+    requestId = String(started.request_id || '');
+    if (!isUuid(requestId)) throw new DeletionError(500, 'request_not_created', 'Account deletion could not start.');
+
+    if (started.status === 'completed') {
+      return json({ completed: true, requestId, result: completedResult() });
+    }
+
+    if (!['database_deleted', 'auth_deleting'].includes(String(started.status || ''))) {
+      const familyIds = normalizeFamilyIds(started.sole_family_ids);
+      const explicitPaths = normalizeFamilyStoragePathsForFamilies(familyIds, started.storage_paths);
+      const storageDeleted = await deleteSupabaseStorage({ familyIds, explicitPaths });
+      const streamDeleted = await deleteCloudflareStream({
+        familyIds,
+        knownUids: normalizeStreamUids(started.stream_uids),
+      });
+      const r2DeleteRequests = await deleteR2Originals({
+        familyIds,
+        objectIds: normalizeProviderObjectIds(started.r2_object_ids),
+      });
+      const stripeCanceled = await cancelStripeSubscriptions(started.stripe_subscription_ids);
+
+      cleanupSummary = providerCleanupSummary({
+        storageDeleted,
+        streamDeleted,
+        r2DeleteRequests,
+        stripeCanceled,
+      });
+      await rpc('mark_account_deletion_status', {
+        target_user_id: user.id,
+        target_request_id: requestId,
+        next_status: 'provider_cleaned',
+        summary: cleanupSummary,
+        error_code: null,
+      });
+      await rpc('finalize_account_deletion', {
+        target_user_id: user.id,
+        target_request_id: requestId,
+      });
+    }
+
+    await rpc('mark_account_deletion_status', {
+      target_user_id: user.id,
+      target_request_id: requestId,
+      next_status: 'auth_deleting',
+      summary: {},
+      error_code: null,
+    });
+    await deleteAuthUser(user.id);
+    await rpc('mark_account_deletion_status', {
+      target_user_id: user.id,
+      target_request_id: requestId,
+      next_status: 'completed',
+      summary: {},
+      error_code: null,
+    }).catch(() => undefined);
+
+    return json({
+      completed: true,
+      requestId,
+      result: completedResult(),
+    });
+  } catch (error) {
+    if (requestId && userId) {
+      const code = error instanceof DeletionError ? error.code : 'cleanup_failed';
+      await rpc('mark_account_deletion_status', {
+        target_user_id: userId,
+        target_request_id: requestId,
+        next_status: 'cleanup_failed',
+        summary: cleanupSummary,
+        error_code: code,
+      }).catch(() => undefined);
+    }
+    return deletionErrorResponse(error);
+  }
+});
+
+async function verifyDeletionOtp({
+  email,
+  otp,
+  expectedUserId,
+}: {
+  email: string;
+  otp: string;
+  expectedUserId: string;
+}) {
+  const response = await fetch(`${requiredEnv('SUPABASE_URL')}/auth/v1/verify`, {
+    method: 'POST',
+    headers: {
+      apikey: env('SUPABASE_ANON_KEY') || requiredEnv('SUPABASE_SERVICE_ROLE_KEY'),
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ email, token: otp, type: 'email' }),
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok || payload?.user?.id !== expectedUserId) {
+    throw new DeletionError(401, 'reauthentication_failed', 'That code is invalid or expired. Send a fresh code and try again.');
+  }
+}
+
+async function deleteSupabaseStorage({
+  familyIds,
+  explicitPaths,
+}: {
+  familyIds: string[];
+  explicitPaths: string[];
+}) {
+  if (!familyIds.length) return 0;
+  const discovered = new Set(explicitPaths);
+  for (const familyId of familyIds) {
+    const paths = await listFamilyStoragePaths(familyId);
+    paths.forEach((path) => discovered.add(path));
+  }
+
+  const paths = [...discovered].sort();
+  for (let offset = 0; offset < paths.length; offset += 100) {
+    const chunk = paths.slice(offset, offset + 100);
+    await supabaseRequest(`/storage/v1/object/${ACCOUNT_DELETION_STORAGE_BUCKET}`, {
+      method: 'DELETE',
+      body: JSON.stringify({ prefixes: chunk }),
+    });
+  }
+
+  for (const familyId of familyIds) {
+    const remaining = await listFamilyStoragePaths(familyId);
+    if (remaining.length) {
+      throw new DeletionError(503, 'storage_cleanup_incomplete', 'Stored media cleanup did not finish. Try again.');
+    }
+  }
+  return paths.length;
+}
+
+async function listFamilyStoragePaths(familyId: string) {
+  const files = new Set<string>();
+  const pending = [familyId];
+  const visited = new Set<string>();
+
+  while (pending.length) {
+    const prefix = pending.shift() as string;
+    if (visited.has(prefix)) continue;
+    visited.add(prefix);
+    if (visited.size > 10000) {
+      throw new DeletionError(503, 'storage_inventory_too_large', 'Stored media inventory could not finish safely.');
+    }
+
+    let offset = 0;
+    while (true) {
+      const entries = await supabaseRequest(
+        `/storage/v1/object/list/${ACCOUNT_DELETION_STORAGE_BUCKET}`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            prefix,
+            limit: 1000,
+            offset,
+            sortBy: { column: 'name', order: 'asc' },
+          }),
+        },
+      );
+      const page = Array.isArray(entries) ? entries as Array<Record<string, unknown>> : [];
+      const split = splitStorageListing(familyId, prefix, page);
+      split.files.forEach((path) => files.add(path));
+      split.folders.forEach((folder) => {
+        if (!visited.has(folder)) pending.push(folder);
+      });
+      if (page.length < 1000) break;
+      offset += page.length;
+    }
+  }
+
+  return [...files].sort();
+}
+
+async function deleteCloudflareStream({
+  familyIds,
+  knownUids,
+}: {
+  familyIds: string[];
+  knownUids: string[];
+}) {
+  if (!familyIds.length && !knownUids.length) return 0;
+  const accountId = env('CLOUDFLARE_ACCOUNT_ID');
+  const apiToken = env('CLOUDFLARE_API_TOKEN');
+  if (!accountId || !apiToken) {
+    if (isLocalSupabaseRuntime() && !knownUids.length) return 0;
+    throw new DeletionError(503, 'stream_cleanup_unavailable', 'Video cleanup is temporarily unavailable. Try again.');
+  }
+
+  const familySet = new Set(familyIds);
+  const uids = new Set(knownUids);
+  let page = 1;
+  let totalPages = 1;
+
+  do {
+    const response = await cloudflareRequest(
+      accountId,
+      apiToken,
+      `/stream?per_page=1000&page=${page}`,
+      { method: 'GET' },
+    );
+    const videos = Array.isArray(response?.result) ? response.result : [];
+    for (const video of videos) {
+      if (familySet.has(String(video?.meta?.familyId || ''))) {
+        normalizeStreamUids([video?.uid]).forEach((uid) => uids.add(uid));
+      }
+    }
+    totalPages = Math.max(1, Math.min(1000, Number(response?.result_info?.total_pages || 1)));
+    page += 1;
+  } while (page <= totalPages);
+
+  const ids = [...uids];
+  for (let offset = 0; offset < ids.length; offset += 10) {
+    await Promise.all(ids.slice(offset, offset + 10).map((uid) =>
+      cloudflareRequest(accountId, apiToken, `/stream/${encodeURIComponent(uid)}`, { method: 'DELETE' }, true)
+    ));
+  }
+  return ids.length;
+}
+
+async function cloudflareRequest(
+  accountId: string,
+  apiToken: string,
+  path: string,
+  init: RequestInit,
+  allowNotFound = false,
+) {
+  const response = await fetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}${path}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${apiToken}`,
+      'content-type': 'application/json',
+      ...(init.headers || {}),
+    },
+  });
+  const payload = await response.json().catch(() => null);
+  if (!response.ok && !(allowNotFound && response.status === 404)) {
+    throw new DeletionError(503, 'stream_cleanup_failed', 'Video cleanup did not finish. Try again.');
+  }
+  return payload || {};
+}
+
+async function deleteR2Originals({
+  familyIds,
+  objectIds,
+}: {
+  familyIds: string[];
+  objectIds: string[];
+}) {
+  if (!familyIds.length) return 0;
+  const baseUrl = env('MEDIA_GATEWAY_INTERNAL_URL').replace(/\/+$/, '');
+  const secret = env('MEDIA_DELETION_SECRET');
+  if (!baseUrl || !secret) {
+    if (isLocalSupabaseRuntime() && !objectIds.length) return 0;
+    throw new DeletionError(503, 'original_cleanup_unavailable', 'Original-backup cleanup is temporarily unavailable. Try again.');
+  }
+
+  let requests = 0;
+  for (const familyId of familyIds) {
+    const response = await fetch(`${baseUrl}/internal/account-deletion`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${secret}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ familyId, objectIds }),
+    });
+    if (!response.ok) {
+      throw new DeletionError(503, 'original_cleanup_failed', 'Original-backup cleanup did not finish. Try again.');
+    }
+    requests += 1;
+  }
+  return requests;
+}
+
+async function cancelStripeSubscriptions(values: unknown) {
+  const subscriptionIds = normalizeProviderObjectIds(values);
+  if (!subscriptionIds.length) return 0;
+  const secret = env('STRIPE_SECRET_KEY');
+  if (!secret) {
+    throw new DeletionError(503, 'billing_cleanup_unavailable', 'Web subscription cancellation is temporarily unavailable. Try again.');
+  }
+
+  for (const subscriptionId of subscriptionIds) {
+    const response = await fetch(`https://api.stripe.com/v1/subscriptions/${encodeURIComponent(subscriptionId)}`, {
+      method: 'DELETE',
+      headers: { authorization: `Bearer ${secret}` },
+    });
+    if (!response.ok && response.status !== 404) {
+      throw new DeletionError(503, 'billing_cleanup_failed', 'Web subscription cancellation did not finish. Try again.');
+    }
+  }
+  return subscriptionIds.length;
+}
+
+async function deleteAuthUser(userId: string) {
+  const response = await fetch(
+    `${requiredEnv('SUPABASE_URL')}/auth/v1/admin/users/${encodeURIComponent(userId)}?should_soft_delete=false`,
+    {
+      method: 'DELETE',
+      headers: {
+        apikey: requiredEnv('SUPABASE_SERVICE_ROLE_KEY'),
+        authorization: `Bearer ${requiredEnv('SUPABASE_SERVICE_ROLE_KEY')}`,
+      },
+    },
+  );
+  if (!response.ok && response.status !== 404) {
+    throw new DeletionError(503, 'auth_cleanup_failed', 'Account sign-in cleanup did not finish. Try again.');
+  }
+}
+
+function normalizeFamilyStoragePathsForFamilies(familyIds: string[], values: unknown) {
+  const paths = new Set<string>();
+  for (const familyId of familyIds) {
+    normalizeFamilyStoragePaths(familyId, values).forEach((path) => paths.add(path));
+  }
+  return [...paths].sort();
+}
+
+function completedResult() {
+  return {
+    accountDeleted: true,
+    cameraRollOriginalsDeleted: false,
+    sharedFamilyHistoryPreservedWhenOtherWritersRemain: true,
+  };
+}
+
+function isLocalSupabaseRuntime() {
+  try {
+    const host = new URL(env('SUPABASE_URL')).hostname;
+    return host === '127.0.0.1'
+      || host === 'localhost'
+      || host === 'host.docker.internal'
+      || host === 'kong'
+      || host.startsWith('supabase_kong_');
+  } catch {
+    return false;
+  }
+}
+
+function asRecord(value: unknown): Record<string, any> {
+  if (Array.isArray(value)) return (value[0] || {}) as Record<string, any>;
+  return value && typeof value === 'object' ? value as Record<string, any> : {};
+}
+
+function deletionErrorResponse(error: unknown) {
+  if (error instanceof DeletionError) {
+    return json({ error: error.message, code: error.code }, error.status);
+  }
+  if (error instanceof Error && error.message === 'Type DELETE to confirm account deletion.') {
+    return json({ error: error.message, code: 'confirmation_required' }, 400);
+  }
+  return json({
+    error: 'Account deletion did not finish. Send a fresh code and try again.',
+    code: 'deletion_failed',
+  }, 500);
+}

--- a/supabase/migrations/20260724120000_account_deletion_lifecycle.sql
+++ b/supabase/migrations/20260724120000_account_deletion_lifecycle.sql
@@ -1,0 +1,796 @@
+-- Idempotent, role-aware account deletion lifecycle.
+--
+-- The Edge orchestrator performs provider cleanup before this migration's
+-- finalizer removes database state. Family locks close the race where a new
+-- Keep, upload, or membership change could arrive after provider inventory.
+-- Audit rows contain identifiers, roles, timestamps, status, and aggregate
+-- provider outcomes only; they never contain family-authored content or local
+-- discovery state.
+
+create table if not exists public.account_deletion_requests (
+  id                    uuid primary key,
+  requester_user_id     uuid not null unique,
+  family_roles          jsonb not null default '[]'::jsonb,
+  status                text not null default 'prepared' check (status in (
+    'prepared',
+    'provider_cleaned',
+    'cleanup_failed',
+    'database_deleted',
+    'auth_deleting',
+    'completed',
+    'blocked_legal_hold',
+    'failed'
+  )),
+  legal_hold            boolean not null default false,
+  reauthenticated_at    timestamptz not null,
+  provider_summary      jsonb not null default '{}'::jsonb,
+  attempts              integer not null default 1 check (attempts > 0),
+  last_error_code       text,
+  requested_at          timestamptz not null default now(),
+  provider_cleaned_at   timestamptz,
+  database_deleted_at   timestamptz,
+  auth_deleted_at       timestamptz,
+  completed_at          timestamptz,
+  updated_at            timestamptz not null default now()
+);
+
+create index if not exists account_deletion_requests_status_idx
+  on public.account_deletion_requests(status, updated_at);
+
+create table if not exists public.account_deletion_family_locks (
+  family_id             uuid primary key references public.families(id) on delete cascade,
+  request_id            uuid not null references public.account_deletion_requests(id) on delete cascade,
+  requester_user_id     uuid not null,
+  expires_at            timestamptz not null default now() + interval '30 minutes',
+  created_at            timestamptz not null default now()
+);
+
+create index if not exists account_deletion_family_locks_request_idx
+  on public.account_deletion_family_locks(request_id, expires_at);
+
+alter table public.account_deletion_requests enable row level security;
+alter table public.account_deletion_family_locks enable row level security;
+
+revoke all on table public.account_deletion_requests from public, anon, authenticated;
+revoke all on table public.account_deletion_family_locks from public, anon, authenticated;
+grant select, insert, update, delete on table public.account_deletion_requests to service_role;
+grant select, insert, update, delete on table public.account_deletion_family_locks to service_role;
+
+drop trigger if exists account_deletion_requests_updated on public.account_deletion_requests;
+create trigger account_deletion_requests_updated
+  before update on public.account_deletion_requests
+  for each row execute procedure public.ool_set_updated_at();
+
+create or replace function public.family_deletion_locked(fid uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_catalog
+as $$
+  select exists (
+    select 1
+    from public.account_deletion_family_locks lock
+    where lock.family_id = fid
+      and lock.expires_at > now()
+  );
+$$;
+
+revoke all on function public.family_deletion_locked(uuid) from public, anon;
+grant execute on function public.family_deletion_locked(uuid) to authenticated, service_role;
+
+-- Every established writer mutation gate calls is_family_writer. Making an
+-- active deletion lock fail this predicate pauses direct API, Storage, and RPC
+-- writes while provider cleanup is in flight.
+create or replace function public.is_family_writer(fid uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_catalog
+as $$
+  select
+    not public.family_deletion_locked(fid)
+    and exists (
+      select 1
+      from public.family_members
+      where family_id = fid
+        and user_id = auth.uid()
+        and role in ('creator', 'partner')
+    );
+$$;
+
+revoke all on function public.is_family_writer(uuid) from public, anon;
+grant execute on function public.is_family_writer(uuid) to authenticated;
+
+create or replace function public.guard_family_membership_during_deletion()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_catalog
+as $$
+declare
+  target_family_id uuid;
+begin
+  target_family_id := case when tg_op = 'DELETE' then old.family_id else new.family_id end;
+  if public.family_deletion_locked(target_family_id) then
+    raise exception 'family account deletion is in progress'
+      using errcode = '55000';
+  end if;
+  return coalesce(new, old);
+end
+$$;
+
+drop trigger if exists family_members_deletion_lock on public.family_members;
+create trigger family_members_deletion_lock
+  before insert or update or delete on public.family_members
+  for each row execute procedure public.guard_family_membership_during_deletion();
+
+create or replace function public.preview_account_deletion(target_user_id uuid)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public, pg_catalog
+as $$
+  with memberships as (
+    select
+      fm.family_id,
+      fm.role,
+      (
+        select count(*)::integer
+        from public.family_members writers
+        where writers.family_id = fm.family_id
+          and writers.role in ('creator', 'partner')
+      ) as writer_count,
+      fe.source as billing_source,
+      fe.billing_owner_user_id
+    from public.family_members fm
+    left join public.family_entitlements fe on fe.family_id = fm.family_id
+    where fm.user_id = target_user_id
+  ), classified as (
+    select
+      role,
+      case
+        when role = 'circle' then 'circle_member'
+        when writer_count <= 1 then 'sole_writer'
+        else 'additional_writer'
+      end as disposition,
+      coalesce(billing_source, 'none') as billing_source,
+      billing_owner_user_id = target_user_id as is_billing_owner
+    from memberships
+  )
+  select jsonb_build_object(
+    'family_count', (select count(*) from classified),
+    'sole_writer_count', (select count(*) from classified where disposition = 'sole_writer'),
+    'additional_writer_count', (select count(*) from classified where disposition = 'additional_writer'),
+    'circle_count', (select count(*) from classified where disposition = 'circle_member'),
+    'store_subscription_action_required', exists (
+      select 1
+      from classified
+      where billing_source in ('apple', 'google')
+        and (disposition = 'sole_writer' or is_billing_owner)
+    ),
+    'stripe_cancellation_required', exists (
+      select 1
+      from classified
+      where billing_source = 'stripe'
+        and (disposition = 'sole_writer' or is_billing_owner)
+    )
+  );
+$$;
+
+revoke all on function public.preview_account_deletion(uuid) from public, anon, authenticated;
+grant execute on function public.preview_account_deletion(uuid) to service_role;
+
+alter table public.media_upload_reservations
+  add column if not exists provider text
+    check (provider is null or provider in ('supabase', 'stream', 'r2')),
+  add column if not exists provider_object_id text;
+
+create index if not exists media_upload_reservations_provider_object_idx
+  on public.media_upload_reservations(provider, provider_object_id)
+  where provider_object_id is not null;
+
+create or replace function public.begin_account_deletion(
+  target_user_id uuid,
+  proposed_request_id uuid,
+  reauthenticated_at timestamptz
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = public, pg_catalog
+as $$
+declare
+  effective_request_id uuid;
+  member record;
+  classifications jsonb := '[]'::jsonb;
+  audit_roles jsonb := '[]'::jsonb;
+  sole_family_ids uuid[] := array[]::uuid[];
+  storage_paths jsonb := '[]'::jsonb;
+  stream_uids jsonb := '[]'::jsonb;
+  r2_object_ids jsonb := '[]'::jsonb;
+  stripe_subscription_ids jsonb := '[]'::jsonb;
+  existing_status text;
+  deletion_legal_hold boolean;
+begin
+  if target_user_id is null or proposed_request_id is null then
+    raise exception 'deletion request scope is required';
+  end if;
+  if reauthenticated_at is null or reauthenticated_at < now() - interval '15 minutes' then
+    raise exception 'recent reauthentication is required';
+  end if;
+  if not exists (select 1 from auth.users where id = target_user_id) then
+    raise exception 'account not found';
+  end if;
+  if exists (
+    select 1
+    from public.account_deletion_requests
+    where id = proposed_request_id
+      and requester_user_id <> target_user_id
+  ) then
+    raise exception 'deletion request does not belong to this account';
+  end if;
+
+  insert into public.account_deletion_requests (
+    id,
+    requester_user_id,
+    reauthenticated_at,
+    status
+  )
+  values (
+    proposed_request_id,
+    target_user_id,
+    reauthenticated_at,
+    'prepared'
+  )
+  on conflict (requester_user_id) do update
+  set
+    reauthenticated_at = excluded.reauthenticated_at,
+    status = case
+      when public.account_deletion_requests.status in ('database_deleted', 'auth_deleting', 'completed')
+        then public.account_deletion_requests.status
+      else 'prepared'
+    end,
+    attempts = public.account_deletion_requests.attempts + 1,
+    last_error_code = null
+  returning id, status, legal_hold
+  into effective_request_id, existing_status, deletion_legal_hold;
+
+  if deletion_legal_hold then
+    raise exception 'account deletion is blocked by a legal hold';
+  end if;
+
+  if existing_status in ('database_deleted', 'auth_deleting', 'completed') then
+    return jsonb_build_object(
+      'request_id', effective_request_id,
+      'status', existing_status,
+      'classifications', '[]'::jsonb,
+      'sole_family_ids', '[]'::jsonb,
+      'storage_paths', '[]'::jsonb,
+      'stream_uids', '[]'::jsonb,
+      'r2_object_ids', '[]'::jsonb,
+      'stripe_subscription_ids', '[]'::jsonb
+    );
+  end if;
+
+  delete from public.account_deletion_family_locks
+  where request_id = effective_request_id
+     or (requester_user_id = target_user_id and expires_at <= now());
+
+  for member in
+    select
+      fm.family_id,
+      fm.role,
+      (
+        select count(*)::integer
+        from public.family_members writers
+        where writers.family_id = fm.family_id
+          and writers.role in ('creator', 'partner')
+      ) as writer_count,
+      coalesce(fe.source, 'none') as billing_source,
+      fe.billing_owner_user_id = target_user_id as is_billing_owner
+    from public.family_members fm
+    left join public.family_entitlements fe on fe.family_id = fm.family_id
+    where fm.user_id = target_user_id
+    order by fm.family_id
+  loop
+    perform 1 from public.families where id = member.family_id for update;
+
+    insert into public.account_deletion_family_locks (
+      family_id,
+      request_id,
+      requester_user_id,
+      expires_at
+    )
+    values (
+      member.family_id,
+      effective_request_id,
+      target_user_id,
+      now() + interval '30 minutes'
+    )
+    on conflict (family_id) do update
+    set
+      request_id = excluded.request_id,
+      requester_user_id = excluded.requester_user_id,
+      expires_at = excluded.expires_at;
+
+    classifications := classifications || jsonb_build_array(jsonb_build_object(
+      'family_id', member.family_id,
+      'role', member.role,
+      'writer_count', member.writer_count,
+      'disposition', case
+        when member.role = 'circle' then 'circle_member'
+        when member.writer_count <= 1 then 'sole_writer'
+        else 'additional_writer'
+      end,
+      'billing_source', member.billing_source,
+      'is_billing_owner', member.is_billing_owner
+    ));
+
+    audit_roles := audit_roles || jsonb_build_array(jsonb_build_object(
+      'family_id', member.family_id,
+      'role', member.role,
+      'disposition', case
+        when member.role = 'circle' then 'circle_member'
+        when member.writer_count <= 1 then 'sole_writer'
+        else 'additional_writer'
+      end
+    ));
+
+    if member.role <> 'circle' and member.writer_count <= 1 then
+      sole_family_ids := array_append(sole_family_ids, member.family_id);
+    end if;
+  end loop;
+
+  if coalesce(array_length(sole_family_ids, 1), 0) > 0 then
+    select coalesce(jsonb_agg(distinct path order by path), '[]'::jsonb)
+    into storage_paths
+    from (
+      select mm.family_id, mm.metadata ->> 'fullPath' as path
+      from public.moment_media mm
+      where mm.family_id = any(sole_family_ids)
+      union all
+      select mm.family_id, mm.metadata ->> 'thumbPath'
+      from public.moment_media mm
+      where mm.family_id = any(sole_family_ids)
+      union all
+      select mm.family_id, mm.metadata ->> 'posterPath'
+      from public.moment_media mm
+      where mm.family_id = any(sole_family_ids)
+      union all
+      select pt.family_id, pt.family_id::text || '/full/' || pt.storage_object::text || '.jpg'
+      from public.photo_tags pt
+      where pt.family_id = any(sole_family_ids) and pt.storage_object is not null
+      union all
+      select pt.family_id, pt.family_id::text || '/thumb/' || pt.thumb_object::text || '.jpg'
+      from public.photo_tags pt
+      where pt.family_id = any(sole_family_ids) and pt.thumb_object is not null
+      union all
+      select
+        vn.family_id,
+        case
+          when vn.moment_id is not null then
+            vn.family_id::text || '/moments/' || vn.moment_id::text || '/voice/' || vn.audio_object::text || '.' ||
+            case
+              when vn.mime_type = 'audio/mpeg' then 'mp3'
+              when vn.mime_type = 'audio/aac' then 'aac'
+              when vn.mime_type = 'audio/webm' then 'webm'
+              else 'm4a'
+            end
+          when vn.letter_id is not null then
+            vn.family_id::text || '/letters/' || vn.letter_id::text || '/voice/' || vn.audio_object::text || '.' ||
+            case
+              when vn.mime_type = 'audio/mpeg' then 'mp3'
+              when vn.mime_type = 'audio/aac' then 'aac'
+              when vn.mime_type = 'audio/webm' then 'webm'
+              else 'm4a'
+            end
+          else null
+        end
+      from public.voice_notes vn
+      where vn.family_id = any(sole_family_ids) and vn.audio_object is not null
+    ) candidates
+    where path is not null
+      and path like family_id::text || '/%';
+
+    select coalesce(jsonb_agg(distinct uid order by uid), '[]'::jsonb)
+    into stream_uids
+    from (
+      select mm.stream_uid as uid
+      from public.moment_media mm
+      where mm.family_id = any(sole_family_ids)
+        and mm.stream_uid is not null
+      union all
+      select mur.provider_object_id
+      from public.media_upload_reservations mur
+      where mur.family_id = any(sole_family_ids)
+        and mur.provider = 'stream'
+        and mur.provider_object_id is not null
+    ) provider_objects;
+
+    select coalesce(jsonb_agg(distinct object_id order by object_id), '[]'::jsonb)
+    into r2_object_ids
+    from (
+      select mm.original_object::text as object_id
+      from public.moment_media mm
+      where mm.family_id = any(sole_family_ids)
+        and mm.original_object is not null
+      union all
+      select mur.provider_object_id
+      from public.media_upload_reservations mur
+      where mur.family_id = any(sole_family_ids)
+        and mur.provider = 'r2'
+        and mur.provider_object_id is not null
+    ) provider_objects;
+  end if;
+
+  select coalesce(jsonb_agg(distinct bs.provider_subscription_id order by bs.provider_subscription_id), '[]'::jsonb)
+  into stripe_subscription_ids
+  from public.billing_subscriptions bs
+  where bs.provider = 'stripe'
+    and bs.provider_subscription_id is not null
+    and bs.status in ('pending', 'active', 'trialing', 'grace_period', 'past_due')
+    and (
+      bs.family_id = any(sole_family_ids)
+      or bs.purchaser_user_id = target_user_id
+    );
+
+  update public.account_deletion_requests
+  set
+    family_roles = audit_roles,
+    status = 'prepared',
+    reauthenticated_at = begin_account_deletion.reauthenticated_at,
+    last_error_code = null
+  where id = effective_request_id;
+
+  return jsonb_build_object(
+    'request_id', effective_request_id,
+    'status', 'prepared',
+    'classifications', classifications,
+    'sole_family_ids', to_jsonb(sole_family_ids),
+    'storage_paths', storage_paths,
+    'stream_uids', stream_uids,
+    'r2_object_ids', r2_object_ids,
+    'stripe_subscription_ids', stripe_subscription_ids
+  );
+end
+$$;
+
+revoke all on function public.begin_account_deletion(uuid, uuid, timestamptz) from public, anon, authenticated;
+grant execute on function public.begin_account_deletion(uuid, uuid, timestamptz) to service_role;
+
+create or replace function public.attach_media_upload_provider_object(
+  p_reservation_id uuid,
+  p_provider text,
+  p_provider_object_id text
+)
+returns void
+language plpgsql
+volatile
+security definer
+set search_path = public, pg_catalog
+as $$
+declare
+  reservation public.media_upload_reservations%rowtype;
+begin
+  if auth.uid() is null then
+    raise exception 'must be signed in';
+  end if;
+  if p_provider not in ('stream', 'r2') or nullif(trim(p_provider_object_id), '') is null then
+    raise exception 'provider upload identity is invalid';
+  end if;
+
+  select * into reservation
+  from public.media_upload_reservations
+  where id = p_reservation_id
+  for update;
+
+  if not found or reservation.user_id is distinct from auth.uid() then
+    raise exception 'reservation not found';
+  end if;
+  if reservation.status <> 'reserved' then
+    raise exception 'reservation is no longer open';
+  end if;
+  if not public.is_family_writer(reservation.family_id) then
+    raise exception 'Only a co-parent can attach provider media.';
+  end if;
+
+  update public.media_upload_reservations
+  set
+    provider = p_provider,
+    provider_object_id = trim(p_provider_object_id)
+  where id = p_reservation_id;
+end
+$$;
+
+revoke all on function public.attach_media_upload_provider_object(uuid, text, text) from public, anon;
+grant execute on function public.attach_media_upload_provider_object(uuid, text, text) to authenticated;
+
+create or replace function public.mark_account_deletion_status(
+  target_user_id uuid,
+  target_request_id uuid,
+  next_status text,
+  summary jsonb default '{}'::jsonb,
+  error_code text default null
+)
+returns void
+language plpgsql
+volatile
+security definer
+set search_path = public, pg_catalog
+as $$
+begin
+  if next_status not in ('provider_cleaned', 'cleanup_failed', 'auth_deleting', 'completed', 'failed') then
+    raise exception 'invalid deletion status transition';
+  end if;
+
+  update public.account_deletion_requests
+  set
+    status = next_status,
+    provider_summary = case
+      when next_status in ('provider_cleaned', 'cleanup_failed') then coalesce(summary, '{}'::jsonb)
+      else provider_summary
+    end,
+    last_error_code = left(nullif(error_code, ''), 80),
+    provider_cleaned_at = case when next_status = 'provider_cleaned' then now() else provider_cleaned_at end,
+    auth_deleted_at = case when next_status = 'completed' then now() else auth_deleted_at end,
+    completed_at = case when next_status = 'completed' then now() else completed_at end
+  where id = target_request_id
+    and requester_user_id = target_user_id;
+
+  if not found then
+    raise exception 'deletion request not found';
+  end if;
+end
+$$;
+
+revoke all on function public.mark_account_deletion_status(uuid, uuid, text, jsonb, text) from public, anon, authenticated;
+grant execute on function public.mark_account_deletion_status(uuid, uuid, text, jsonb, text) to service_role;
+
+create or replace function public.finalize_account_deletion(
+  target_user_id uuid,
+  target_request_id uuid
+)
+returns jsonb
+language plpgsql
+volatile
+security definer
+set search_path = public, pg_catalog
+as $$
+declare
+  request_row public.account_deletion_requests%rowtype;
+  member record;
+  expected_disposition text;
+  actual_disposition text;
+  deleted_family_count integer := 0;
+  left_family_count integer := 0;
+  circle_count integer := 0;
+  affected_family_ids uuid[] := array[]::uuid[];
+begin
+  select * into request_row
+  from public.account_deletion_requests
+  where id = target_request_id
+    and requester_user_id = target_user_id
+  for update;
+
+  if not found then
+    raise exception 'deletion request not found';
+  end if;
+  if request_row.legal_hold then
+    update public.account_deletion_requests
+    set status = 'blocked_legal_hold', last_error_code = 'legal_hold'
+    where id = target_request_id;
+    raise exception 'account deletion is blocked by a legal hold';
+  end if;
+  if request_row.status = 'database_deleted' then
+    return jsonb_build_object(
+      'deleted_family_count', 0,
+      'left_family_count', 0,
+      'circle_count', 0,
+      'already_finalized', true
+    );
+  end if;
+  if request_row.status <> 'provider_cleaned' then
+    raise exception 'provider cleanup must finish before database deletion';
+  end if;
+
+  for member in
+    select
+      fm.family_id,
+      fm.role,
+      (
+        select count(*)::integer
+        from public.family_members writers
+        where writers.family_id = fm.family_id
+          and writers.role in ('creator', 'partner')
+      ) as writer_count
+    from public.family_members fm
+    where fm.user_id = target_user_id
+    order by fm.family_id
+    for update of fm
+  loop
+    perform 1
+    from public.account_deletion_family_locks lock
+    where lock.family_id = member.family_id
+      and lock.request_id = target_request_id
+      and lock.requester_user_id = target_user_id
+      and lock.expires_at > now();
+    if not found then
+      raise exception 'deletion family lock expired';
+    end if;
+
+    actual_disposition := case
+      when member.role = 'circle' then 'circle_member'
+      when member.writer_count <= 1 then 'sole_writer'
+      else 'additional_writer'
+    end;
+
+    select role ->> 'disposition'
+    into expected_disposition
+    from jsonb_array_elements(request_row.family_roles) role
+    where (role ->> 'family_id')::uuid = member.family_id
+    limit 1;
+
+    if expected_disposition is distinct from actual_disposition then
+      raise exception 'family deletion classification changed';
+    end if;
+
+    affected_family_ids := array_append(affected_family_ids, member.family_id);
+
+    if actual_disposition = 'sole_writer' then
+      update public.billing_subscriptions
+      set
+        purchaser_user_id = case when purchaser_user_id = target_user_id then null else purchaser_user_id end,
+        status = case
+          when provider = 'stripe' and status in ('pending', 'active', 'trialing', 'grace_period', 'past_due') then 'canceled'
+          else status
+        end,
+        current_period_end = case
+          when provider = 'stripe' and status in ('pending', 'active', 'trialing', 'grace_period', 'past_due') then now()
+          else current_period_end
+        end,
+        latest_receipt = '{}'::jsonb,
+        metadata = jsonb_build_object(
+          'account_deleted_at', now(),
+          'deletion_request_id', target_request_id
+        )
+      where family_id = member.family_id;
+
+      update public.billing_events
+      set
+        user_id = case when user_id = target_user_id then null else user_id end,
+        payload = '{}'::jsonb
+      where family_id = member.family_id;
+
+      update public.gift_redemptions
+      set
+        status = 'revoked',
+        redeemed_by_user_id = null,
+        redeemed_family_id = null,
+        metadata = jsonb_build_object(
+          'family_account_deleted_at', now(),
+          'deletion_request_id', target_request_id
+        )
+      where redeemed_family_id = member.family_id;
+
+      update public.partner_grant_codes
+      set
+        status = 'revoked',
+        redeemed_by_user_id = null,
+        redeemed_family_id = null,
+        metadata = jsonb_build_object(
+          'family_account_deleted_at', now(),
+          'deletion_request_id', target_request_id
+        )
+      where redeemed_family_id = member.family_id;
+
+      delete from public.account_deletion_family_locks
+      where family_id = member.family_id and request_id = target_request_id;
+      delete from public.families where id = member.family_id;
+      deleted_family_count := deleted_family_count + 1;
+    else
+      if actual_disposition = 'circle_member' then
+        circle_count := circle_count + 1;
+      else
+        left_family_count := left_family_count + 1;
+      end if;
+
+      update public.family_entitlements
+      set
+        status = case
+          when billing_owner_user_id = target_user_id
+            and source = 'stripe'
+            and status in ('active', 'trialing', 'grace_period', 'past_due')
+            then 'canceled'
+          else status
+        end,
+        expires_at = case
+          when billing_owner_user_id = target_user_id and source = 'stripe' then now()
+          else expires_at
+        end,
+        billing_owner_user_id = case
+          when billing_owner_user_id = target_user_id then null
+          else billing_owner_user_id
+        end,
+        billing_owner_email = case
+          when billing_owner_user_id = target_user_id then null
+          else billing_owner_email
+        end,
+        metadata = case
+          when billing_owner_user_id = target_user_id then
+            jsonb_build_object(
+              'billing_owner_account_deleted_at', now(),
+              'deletion_request_id', target_request_id
+            )
+          else metadata
+        end
+      where family_id = member.family_id;
+
+      delete from public.account_deletion_family_locks
+      where family_id = member.family_id and request_id = target_request_id;
+      delete from public.family_members
+      where family_id = member.family_id and user_id = target_user_id;
+    end if;
+  end loop;
+
+  -- User/device-specific server state is never retained in another family.
+  delete from public.push_tokens where user_id = target_user_id;
+  delete from public.notification_preferences where user_id = target_user_id;
+  delete from public.notification_deliveries where user_id = target_user_id;
+  delete from public.notifications where user_id = target_user_id;
+  delete from public.moment_views where user_id = target_user_id;
+  delete from public.media_import_calibrations where user_id = target_user_id;
+  delete from public.scan_checkpoints where user_id = target_user_id;
+  delete from public.family_library_connections where user_id = target_user_id;
+  delete from public.media_upload_reservations where user_id = target_user_id;
+  delete from public.family_invites
+  where created_by = target_user_id or used_by = target_user_id;
+
+  update public.families set created_by = null where created_by = target_user_id;
+
+  update public.billing_subscriptions
+  set
+    purchaser_user_id = null,
+    latest_receipt = '{}'::jsonb,
+    metadata = jsonb_build_object(
+      'purchaser_account_deleted_at', now(),
+      'deletion_request_id', target_request_id
+    )
+  where purchaser_user_id = target_user_id;
+
+  update public.billing_events
+  set user_id = null, payload = '{}'::jsonb
+  where user_id = target_user_id;
+
+  update public.gift_redemptions
+  set redeemed_by_user_id = null
+  where redeemed_by_user_id = target_user_id;
+
+  update public.partner_grant_codes
+  set redeemed_by_user_id = null
+  where redeemed_by_user_id = target_user_id;
+
+  delete from public.account_deletion_family_locks
+  where requester_user_id = target_user_id;
+
+  update public.account_deletion_requests
+  set
+    status = 'database_deleted',
+    database_deleted_at = now(),
+    last_error_code = null
+  where id = target_request_id;
+
+  return jsonb_build_object(
+    'deleted_family_count', deleted_family_count,
+    'left_family_count', left_family_count,
+    'circle_count', circle_count,
+    'already_finalized', false
+  );
+end
+$$;
+
+revoke all on function public.finalize_account_deletion(uuid, uuid) from public, anon, authenticated;
+grant execute on function public.finalize_account_deletion(uuid, uuid) to service_role;

--- a/supabase/tests/account_deletion_lifecycle_test.sql
+++ b/supabase/tests/account_deletion_lifecycle_test.sql
@@ -1,0 +1,381 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+set search_path = public, extensions;
+select plan(39);
+
+insert into auth.users (
+  instance_id, id, aud, role, email, encrypted_password, email_confirmed_at,
+  created_at, updated_at, raw_app_meta_data, raw_user_meta_data
+) values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    'a0000000-0000-4000-8000-000000000001',
+    'authenticated', 'authenticated', 'delete-target@example.test', '', now(),
+    now(), now(), '{}'::jsonb, '{}'::jsonb
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    'a0000000-0000-4000-8000-000000000002',
+    'authenticated', 'authenticated', 'remaining-writer@example.test', '', now(),
+    now(), now(), '{}'::jsonb, '{}'::jsonb
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    'a0000000-0000-4000-8000-000000000003',
+    'authenticated', 'authenticated', 'legal-hold@example.test', '', now(),
+    now(), now(), '{}'::jsonb, '{}'::jsonb
+  );
+
+insert into public.families (id, name, baby_name, created_by) values
+  ('f0000000-0000-4000-8000-000000000010', 'Sole writer fixture', 'Baby', 'a0000000-0000-4000-8000-000000000001'),
+  ('f0000000-0000-4000-8000-000000000020', 'Shared writer fixture', 'Baby', 'a0000000-0000-4000-8000-000000000002'),
+  ('f0000000-0000-4000-8000-000000000030', 'Circle fixture', 'Baby', 'a0000000-0000-4000-8000-000000000002');
+
+insert into public.family_members (family_id, user_id, display_name, role) values
+  ('f0000000-0000-4000-8000-000000000010', 'a0000000-0000-4000-8000-000000000001', 'Target', 'creator'),
+  ('f0000000-0000-4000-8000-000000000020', 'a0000000-0000-4000-8000-000000000001', 'Target', 'partner'),
+  ('f0000000-0000-4000-8000-000000000020', 'a0000000-0000-4000-8000-000000000002', 'Remaining', 'creator'),
+  ('f0000000-0000-4000-8000-000000000030', 'a0000000-0000-4000-8000-000000000001', 'Target', 'circle'),
+  ('f0000000-0000-4000-8000-000000000030', 'a0000000-0000-4000-8000-000000000002', 'Remaining', 'creator');
+
+insert into public.family_entitlements (
+  family_id, status, source, plan_key, billing_owner_user_id, billing_owner_email, expires_at
+) values
+  (
+    'f0000000-0000-4000-8000-000000000010',
+    'active', 'stripe', 'family_monthly',
+    'a0000000-0000-4000-8000-000000000001',
+    'delete-target@example.test',
+    now() + interval '30 days'
+  ),
+  (
+    'f0000000-0000-4000-8000-000000000020',
+    'active', 'admin', 'comp_year',
+    null, null,
+    now() + interval '30 days'
+  ),
+  (
+    'f0000000-0000-4000-8000-000000000030',
+    'active', 'admin', 'comp_year',
+    null, null,
+    now() + interval '30 days'
+  );
+
+insert into public.billing_subscriptions (
+  id, family_id, purchaser_user_id, provider, product_id, plan_key,
+  provider_subscription_id, status, latest_receipt, metadata
+) values (
+  'b0000000-0000-4000-8000-000000000001',
+  'f0000000-0000-4000-8000-000000000010',
+  'a0000000-0000-4000-8000-000000000001',
+  'stripe',
+  'synthetic-delete-plan',
+  'family_monthly',
+  'sub_synthetic_delete',
+  'active',
+  '{"synthetic":"receipt"}'::jsonb,
+  '{"synthetic":"billing"}'::jsonb
+);
+
+insert into public.moments (id, family_id, author_user_id, title, captured_at) values
+  (
+    'c0000000-0000-4000-8000-000000000010',
+    'f0000000-0000-4000-8000-000000000010',
+    'a0000000-0000-4000-8000-000000000001',
+    'Sole family synthetic moment',
+    now()
+  ),
+  (
+    'c0000000-0000-4000-8000-000000000020',
+    'f0000000-0000-4000-8000-000000000020',
+    'a0000000-0000-4000-8000-000000000001',
+    'Shared family synthetic moment',
+    now()
+  );
+
+insert into public.moment_media (
+  id, moment_id, family_id, owner_user_id, media_type, metadata,
+  stream_uid, original_object, storage_provider, playback_provider
+) values
+  (
+    'd0000000-0000-4000-8000-000000000010',
+    'c0000000-0000-4000-8000-000000000010',
+    'f0000000-0000-4000-8000-000000000010',
+    'a0000000-0000-4000-8000-000000000001',
+    'video',
+    '{"fullPath":"f0000000-0000-4000-8000-000000000010/moments/synthetic/full.mp4"}'::jsonb,
+    'streamSyntheticDelete01',
+    'd0000000-0000-4000-8000-000000000011',
+    'r2',
+    'stream'
+  ),
+  (
+    'd0000000-0000-4000-8000-000000000020',
+    'c0000000-0000-4000-8000-000000000020',
+    'f0000000-0000-4000-8000-000000000020',
+    'a0000000-0000-4000-8000-000000000001',
+    'image',
+    '{"fullPath":"f0000000-0000-4000-8000-000000000020/moments/shared/full.jpg"}'::jsonb,
+    null,
+    null,
+    'supabase',
+    'supabase'
+  );
+
+insert into public.push_tokens (user_id, family_id, expo_push_token, platform)
+values (
+  'a0000000-0000-4000-8000-000000000001',
+  'f0000000-0000-4000-8000-000000000020',
+  'ExponentPushToken[synthetic-account-deletion]',
+  'ios'
+);
+
+select is(
+  (public.preview_account_deletion('a0000000-0000-4000-8000-000000000001') ->> 'family_count')::integer,
+  3,
+  'preview counts every family membership'
+);
+select is(
+  (public.preview_account_deletion('a0000000-0000-4000-8000-000000000001') ->> 'sole_writer_count')::integer,
+  1,
+  'preview identifies the sole-writer family'
+);
+select is(
+  (public.preview_account_deletion('a0000000-0000-4000-8000-000000000001') ->> 'additional_writer_count')::integer,
+  1,
+  'preview identifies the shared writer family'
+);
+select is(
+  (public.preview_account_deletion('a0000000-0000-4000-8000-000000000001') ->> 'circle_count')::integer,
+  1,
+  'preview identifies the circle membership'
+);
+select ok(
+  (public.preview_account_deletion('a0000000-0000-4000-8000-000000000001') ->> 'stripe_cancellation_required')::boolean,
+  'preview requires Stripe cancellation'
+);
+select ok(
+  not (public.preview_account_deletion('a0000000-0000-4000-8000-000000000001') ->> 'store_subscription_action_required')::boolean,
+  'preview does not invent store subscription work'
+);
+
+insert into public.account_deletion_requests (
+  id, requester_user_id, legal_hold, reauthenticated_at
+) values (
+  'e0000000-0000-4000-8000-000000000003',
+  'a0000000-0000-4000-8000-000000000003',
+  true,
+  now()
+);
+select throws_ok(
+  $$ select public.begin_account_deletion(
+    'a0000000-0000-4000-8000-000000000003',
+    'e0000000-0000-4000-8000-000000000003',
+    now()
+  ) $$,
+  'P0001',
+  'account deletion is blocked by a legal hold',
+  'legal hold blocks deletion before provider inventory'
+);
+
+create temporary table deletion_plan (plan jsonb);
+select lives_ok(
+  $$ insert into deletion_plan
+     select public.begin_account_deletion(
+       'a0000000-0000-4000-8000-000000000001',
+       'e0000000-0000-4000-8000-000000000001',
+       now()
+     ) $$,
+  'begin account deletion succeeds after fresh reauthentication'
+);
+select is(
+  (select plan ->> 'request_id' from deletion_plan),
+  'e0000000-0000-4000-8000-000000000001',
+  'begin returns the stable request identity'
+);
+select ok(
+  (select plan -> 'sole_family_ids' from deletion_plan) @> '["f0000000-0000-4000-8000-000000000010"]'::jsonb,
+  'provider plan includes only the sole-writer family'
+);
+select ok(
+  (select plan -> 'storage_paths' from deletion_plan)
+    @> '["f0000000-0000-4000-8000-000000000010/moments/synthetic/full.mp4"]'::jsonb,
+  'provider plan contains the exact sole-family Storage path'
+);
+select ok(
+  not (select plan -> 'storage_paths' from deletion_plan)
+    @> '["f0000000-0000-4000-8000-000000000020/moments/shared/full.jpg"]'::jsonb,
+  'provider plan excludes shared-family Storage paths'
+);
+select ok(
+  (select plan -> 'stream_uids' from deletion_plan) @> '["streamSyntheticDelete01"]'::jsonb,
+  'provider plan records the sole-family Stream object'
+);
+select ok(
+  (select plan -> 'r2_object_ids' from deletion_plan)
+    @> '["d0000000-0000-4000-8000-000000000011"]'::jsonb,
+  'provider plan records the sole-family R2 object'
+);
+select ok(
+  (select plan -> 'stripe_subscription_ids' from deletion_plan) @> '["sub_synthetic_delete"]'::jsonb,
+  'provider plan records the Stripe subscription'
+);
+select is(
+  (select count(*) from public.account_deletion_family_locks
+   where requester_user_id = 'a0000000-0000-4000-8000-000000000001'),
+  3::bigint,
+  'every affected family is locked before cleanup'
+);
+
+set local role authenticated;
+select set_config('request.jwt.claim.sub', 'a0000000-0000-4000-8000-000000000001', true);
+select set_config('request.jwt.claim.role', 'authenticated', true);
+
+select ok(
+  not public.is_family_writer('f0000000-0000-4000-8000-000000000010'),
+  'sole writer loses direct write authority while deletion is locked'
+);
+select ok(
+  not public.is_family_writer('f0000000-0000-4000-8000-000000000020'),
+  'shared writer loses direct write authority while deletion is locked'
+);
+select throws_ok(
+  $$ insert into public.moments (id, family_id, author_user_id, title, captured_at)
+     values (
+       'c0000000-0000-4000-8000-000000000099',
+       'f0000000-0000-4000-8000-000000000020',
+       'a0000000-0000-4000-8000-000000000001',
+       'Lock bypass attempt',
+       now()
+     ) $$,
+  '42501',
+  null,
+  'locked writer cannot add a new shared record'
+);
+select throws_ok(
+  $$ select count(*) from public.account_deletion_requests $$,
+  '42501',
+  null,
+  'authenticated clients cannot read the deletion audit ledger'
+);
+
+reset role;
+select throws_ok(
+  $$ delete from public.family_members
+     where family_id = 'f0000000-0000-4000-8000-000000000020'
+       and user_id = 'a0000000-0000-4000-8000-000000000001' $$,
+  '55000',
+  'family account deletion is in progress',
+  'membership cannot change after provider inventory'
+);
+
+select lives_ok(
+  $$ select public.mark_account_deletion_status(
+    'a0000000-0000-4000-8000-000000000001',
+    'e0000000-0000-4000-8000-000000000001',
+    'provider_cleaned',
+    '{"storage_deleted_count":1,"stream_deleted_count":1,"r2_delete_request_count":1,"stripe_canceled_count":1}'::jsonb,
+    null
+  ) $$,
+  'aggregate provider cleanup can be recorded'
+);
+
+create temporary table deletion_result (result jsonb);
+select lives_ok(
+  $$ insert into deletion_result
+     select public.finalize_account_deletion(
+       'a0000000-0000-4000-8000-000000000001',
+       'e0000000-0000-4000-8000-000000000001'
+     ) $$,
+  'database finalization succeeds after provider cleanup'
+);
+select is(
+  (select count(*) from public.families where id = 'f0000000-0000-4000-8000-000000000010'),
+  0::bigint,
+  'sole-writer family is deleted'
+);
+select is(
+  (select count(*) from public.families where id = 'f0000000-0000-4000-8000-000000000020'),
+  1::bigint,
+  'shared writer family is preserved'
+);
+select is(
+  (select count(*) from public.families where id = 'f0000000-0000-4000-8000-000000000030'),
+  1::bigint,
+  'circle family is preserved'
+);
+select is(
+  (select count(*) from public.family_members where user_id = 'a0000000-0000-4000-8000-000000000001'),
+  0::bigint,
+  'all memberships for the deleted account are removed'
+);
+select is(
+  (select count(*) from public.family_members
+   where family_id in (
+     'f0000000-0000-4000-8000-000000000020',
+     'f0000000-0000-4000-8000-000000000030'
+   )
+     and user_id = 'a0000000-0000-4000-8000-000000000002'),
+  2::bigint,
+  'the remaining writer keeps both families'
+);
+select is(
+  (select count(*) from public.moments where id = 'c0000000-0000-4000-8000-000000000020'),
+  1::bigint,
+  'shared family moment survives database finalization'
+);
+select is(
+  (select count(*) from public.push_tokens where user_id = 'a0000000-0000-4000-8000-000000000001'),
+  0::bigint,
+  'deleted account push tokens are removed'
+);
+select is(
+  (select status from public.account_deletion_requests where id = 'e0000000-0000-4000-8000-000000000001'),
+  'database_deleted',
+  'deletion audit advances to database deleted'
+);
+select ok(
+  (public.finalize_account_deletion(
+    'a0000000-0000-4000-8000-000000000001',
+    'e0000000-0000-4000-8000-000000000001'
+  ) ->> 'already_finalized')::boolean,
+  'database finalization is idempotent'
+);
+select ok(
+  not ((select provider_summary::text from public.account_deletion_requests
+        where id = 'e0000000-0000-4000-8000-000000000001') like '%moments/%'),
+  'audit provider evidence is aggregate-only'
+);
+select is(
+  (select status from public.billing_subscriptions where id = 'b0000000-0000-4000-8000-000000000001'),
+  'canceled',
+  'Stripe subscription record is canceled after provider cleanup'
+);
+select is(
+  (select family_id from public.billing_subscriptions where id = 'b0000000-0000-4000-8000-000000000001'),
+  null::uuid,
+  'retained billing record is detached from deleted family content'
+);
+select is(
+  (select purchaser_user_id from public.billing_subscriptions where id = 'b0000000-0000-4000-8000-000000000001'),
+  null::uuid,
+  'retained billing record is detached from the deleted user'
+);
+select lives_ok(
+  $$ delete from auth.users where id = 'a0000000-0000-4000-8000-000000000001' $$,
+  'authentication account can be hard-deleted after database cleanup'
+);
+select is(
+  (select author_user_id from public.moments where id = 'c0000000-0000-4000-8000-000000000020'),
+  null::uuid,
+  'shared moment attribution is removed after auth deletion'
+);
+select is(
+  (select count(*) from public.moments where id = 'c0000000-0000-4000-8000-000000000020'),
+  1::bigint,
+  'shared moment remains after auth deletion'
+);
+
+select * from finish();
+rollback;

--- a/workers/media-gateway/src/accountDeletion.js
+++ b/workers/media-gateway/src/accountDeletion.js
@@ -1,0 +1,111 @@
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const OBJECT_ID_PATTERN = /^[A-Za-z0-9._-]{1,160}$/;
+const MAX_REQUEST_BYTES = 1024 * 1024;
+
+export function accountDeletionMarkerKey(familyId) {
+  return `_account-deletions/${familyId}`;
+}
+
+export async function handleAccountDeletion(request, env) {
+  if (request.method !== 'POST') return response({ error: 'Method not allowed.' }, 405);
+  if (!env.MEDIA_DELETION_SECRET || !await authorized(request, env.MEDIA_DELETION_SECRET)) {
+    return response({ error: 'Unauthorized.' }, 401);
+  }
+  const contentLength = Number(request.headers.get('content-length') || 0);
+  if (contentLength > MAX_REQUEST_BYTES) return response({ error: 'Request is too large.' }, 413);
+  if (!env.ORIGINALS?.delete || !env.ORIGINALS?.list || !env.ORIGINALS?.put) {
+    return response({ error: 'Original storage is unavailable.' }, 503);
+  }
+
+  const rawBody = await request.text();
+  if (new TextEncoder().encode(rawBody).byteLength > MAX_REQUEST_BYTES) {
+    return response({ error: 'Request is too large.' }, 413);
+  }
+  const body = parseJson(rawBody);
+  const familyId = String(body?.familyId || '').trim();
+  if (!UUID_PATTERN.test(familyId)) return response({ error: 'Family is invalid.' }, 400);
+
+  // Persist a non-content denial marker before deletion. Existing media
+  // sessions can remain cryptographically valid for up to twenty minutes,
+  // and Cache API entries may outlive the R2 object. The read path checks this
+  // marker before cache lookup so neither can expose a deleted-family original.
+  await env.ORIGINALS.put(
+    accountDeletionMarkerKey(familyId),
+    JSON.stringify({ deleted: true }),
+    { httpMetadata: { contentType: 'application/json' } },
+  );
+
+  const objectIds = [...new Set((Array.isArray(body?.objectIds) ? body.objectIds : [])
+    .map((value) => String(value || '').trim())
+    .filter((value) => OBJECT_ID_PATTERN.test(value)))]
+    .slice(0, 5000);
+  const prefix = `${familyId}/`;
+  const keys = new Set(objectIds.map((objectId) => `${prefix}${objectId}`));
+  let cursor;
+  do {
+    const page = await env.ORIGINALS.list({
+      prefix,
+      cursor,
+      limit: 1000,
+    });
+    for (const object of page?.objects || []) {
+      if (String(object?.key || '').startsWith(prefix)) keys.add(object.key);
+    }
+    if (keys.size > 100000) {
+      return response({ error: 'Original inventory is too large to delete safely.' }, 503);
+    }
+    if (page?.truncated && !page?.cursor) {
+      return response({ error: 'Original inventory did not finish.' }, 503);
+    }
+    cursor = page?.truncated ? page.cursor : undefined;
+  } while (cursor);
+
+  const keyList = [...keys];
+  for (let offset = 0; offset < keyList.length; offset += 1000) {
+    await env.ORIGINALS.delete(keyList.slice(offset, offset + 1000));
+  }
+
+  const verification = await env.ORIGINALS.list({ prefix, limit: 1 });
+  if ((verification?.objects || []).length || verification?.truncated) {
+    return response({ error: 'Original cleanup did not finish.' }, 503);
+  }
+
+  return response({ deletedCount: keyList.length, verified: true });
+}
+
+function parseJson(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+async function authorized(request, expectedSecret) {
+  const supplied = String(request.headers.get('authorization') || '').replace(/^Bearer\s+/i, '');
+  const encoder = new TextEncoder();
+  const [suppliedHash, expectedHash] = await Promise.all([
+    crypto.subtle.digest('SHA-256', encoder.encode(supplied)),
+    crypto.subtle.digest('SHA-256', encoder.encode(String(expectedSecret))),
+  ]);
+  if (typeof crypto.subtle.timingSafeEqual === 'function') {
+    return crypto.subtle.timingSafeEqual(suppliedHash, expectedHash);
+  }
+  return timingSafeEqual(new Uint8Array(suppliedHash), new Uint8Array(expectedHash));
+}
+
+function timingSafeEqual(a, b) {
+  const length = Math.max(a.length, b.length);
+  let different = a.length ^ b.length;
+  for (let index = 0; index < length; index += 1) {
+    different |= (a[index] || 0) ^ (b[index] || 0);
+  }
+  return different === 0;
+}
+
+function response(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/workers/media-gateway/src/accountDeletion_test.js
+++ b/workers/media-gateway/src/accountDeletion_test.js
@@ -1,0 +1,120 @@
+import {
+  assertEquals,
+} from 'jsr:@std/assert@1';
+
+import worker from './index.js';
+import { accountDeletionMarkerKey, handleAccountDeletion } from './accountDeletion.js';
+
+const FAMILY_ID = '10000000-0000-4000-8000-000000000001';
+
+Deno.test('R2 account deletion is authenticated and family-prefixed', async () => {
+  const deleted = [];
+  const written = [];
+  const objects = new Set([`${FAMILY_ID}/orphan-original`]);
+  const env = {
+    MEDIA_DELETION_SECRET: 'test-secret',
+    ORIGINALS: {
+      delete: (keys) => {
+        deleted.push(...keys);
+        keys.forEach((key) => objects.delete(key));
+      },
+      put: (key) => written.push(key),
+      list: ({ prefix }) => ({
+        objects: [...objects]
+          .filter((key) => key.startsWith(prefix))
+          .map((key) => ({ key })),
+        truncated: false,
+      }),
+    },
+  };
+  const response = await handleAccountDeletion(new Request('https://worker.test/internal/account-deletion', {
+    method: 'POST',
+    headers: {
+      authorization: 'Bearer test-secret',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      familyId: FAMILY_ID,
+      objectIds: ['original-1', '../other-family', 'original-1'],
+    }),
+  }), env);
+
+  assertEquals(response.status, 200);
+  assertEquals(written, [accountDeletionMarkerKey(FAMILY_ID)]);
+  assertEquals(deleted, [`${FAMILY_ID}/original-1`, `${FAMILY_ID}/orphan-original`]);
+  assertEquals(await response.json(), { deletedCount: 2, verified: true });
+});
+
+Deno.test('R2 account deletion rejects missing secret and invalid family', async () => {
+  const binding = { delete: () => {}, list: () => ({ objects: [], truncated: false }), put: () => {} };
+  const unauthorized = await handleAccountDeletion(new Request('https://worker.test/internal/account-deletion', {
+    method: 'POST',
+    body: '{}',
+  }), { MEDIA_DELETION_SECRET: 'test-secret', ORIGINALS: binding });
+  assertEquals(unauthorized.status, 401);
+
+  const invalid = await handleAccountDeletion(new Request('https://worker.test/internal/account-deletion', {
+    method: 'POST',
+    headers: { authorization: 'Bearer test-secret', 'content-type': 'application/json' },
+    body: JSON.stringify({ familyId: '../family', objectIds: ['original-1'] }),
+  }), { MEDIA_DELETION_SECRET: 'test-secret', ORIGINALS: binding });
+  assertEquals(invalid.status, 400);
+});
+
+Deno.test('R2 account deletion fails closed when verification finds leftovers', async () => {
+  const response = await handleAccountDeletion(new Request('https://worker.test/internal/account-deletion', {
+    method: 'POST',
+    headers: { authorization: 'Bearer test-secret', 'content-type': 'application/json' },
+    body: JSON.stringify({ familyId: FAMILY_ID, objectIds: ['original-1'] }),
+  }), {
+    MEDIA_DELETION_SECRET: 'test-secret',
+    ORIGINALS: {
+      delete: () => {},
+      put: () => {},
+      list: () => ({ objects: [{ key: `${FAMILY_ID}/original-1` }], truncated: false }),
+    },
+  });
+  assertEquals(response.status, 503);
+});
+
+Deno.test('deleted-family marker overrides a valid media session before cache lookup', async () => {
+  const secret = 'media-session-test-secret';
+  const expires = Math.floor(Date.now() / 1000) + 60;
+  const body = base64url(new TextEncoder().encode(JSON.stringify({
+    f: FAMILY_ID,
+    u: '10000000-0000-4000-8000-000000000002',
+    t: 'vault',
+    exp: expires,
+  })));
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(body));
+  const token = `${body}.${base64url(new Uint8Array(signature))}`;
+
+  const response = await worker.fetch(
+    new Request(`https://worker.test/media/${FAMILY_ID}/original/original-1?session=${token}`),
+    {
+      MEDIA_SESSION_SECRET: secret,
+      ORIGINALS: {
+        head: (objectKey) => objectKey === accountDeletionMarkerKey(FAMILY_ID) ? {} : null,
+      },
+    },
+    { waitUntil: () => {} },
+  );
+
+  assertEquals(response.status, 410);
+  assertEquals(response.headers.get('x-olw-cache'), 'denied');
+});
+
+function base64url(bytes) {
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}

--- a/workers/media-gateway/src/index.js
+++ b/workers/media-gateway/src/index.js
@@ -10,11 +10,16 @@
  * object key + variant — never by bearer token.
  */
 
+import { accountDeletionMarkerKey, handleAccountDeletion } from './accountDeletion.js';
+
 const VARIANTS = new Set(['original', 'stream']);
 
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
+    if (url.pathname === '/internal/account-deletion') {
+      return handleAccountDeletion(request, env);
+    }
     const match = url.pathname.match(/^\/media\/([0-9a-f-]{36})\/([a-z_]+)\/([A-Za-z0-9._-]+)$/);
     if (!match) return withMetrics(new Response('Not found', { status: 404 }), 'miss');
     const [, familyId, variant, objectId] = match;
@@ -44,6 +49,12 @@ export default {
       const path = playbackToken || objectId;
       const playback = `https://${env.STREAM_CUSTOMER_DOMAIN}/${path}/manifest/video.m3u8`;
       return withMetrics(Response.redirect(playback, 302), 'redirect');
+    }
+
+    // A deletion marker overrides previously issued media sessions and any
+    // still-live Cache API entry. It contains no family content.
+    if (await env.ORIGINALS.head(accountDeletionMarkerKey(familyId))) {
+      return withMetrics(new Response('Family media was deleted', { status: 410 }), 'denied');
     }
 
     // 4. Cache by object key + variant after auth (never by token).

--- a/workers/media-gateway/wrangler.toml
+++ b/workers/media-gateway/wrangler.toml
@@ -2,9 +2,11 @@
 # Deploy AFTER R2 is enabled and the olw-originals bucket exists:
 #   npx wrangler deploy
 #   npx wrangler secret put MEDIA_SESSION_SECRET   # must match the Supabase secret
+#   npx wrangler secret put MEDIA_DELETION_SECRET  # must match the Supabase secret
 name = "olw-media-gateway"
 main = "src/index.js"
-compatibility_date = "2026-07-01"
+compatibility_date = "2026-07-24"
+compatibility_flags = [ "nodejs_compat" ]
 
 [[r2_buckets]]
 binding = "ORIGINALS"


### PR DESCRIPTION
## Outcome

- adds a role-aware, idempotent deletion lifecycle for sole writers, additional writers, and Circle members
- verifies Supabase Storage, Cloudflare Stream, and R2 cleanup before database/Auth deletion
- preserves shared family history with nullable authorship and clears private local device state
- exposes an export-first, fresh-OTP, exact-`DELETE` mobile journey across setup, family, subscription, and lapsed gates
- records production deployment and recovery boundaries without changing production state

## Privacy

Private discovery candidates, local Photos identifiers, face evidence, fingerprints, selection rationale, rejects, drafts, and Tonight queue state remain device-only. Deletion audit and release evidence are aggregate-only. The R2 Worker writes a content-free deletion marker so a still-valid media session cannot serve a stale cached original.

## Verification

- frozen dependency install
- `pnpm test` — 448 mobile tests and web type contract
- `pnpm lint`, `pnpm typecheck`, `pnpm build`
- Expo lint and Expo Doctor — 20/20
- fresh `pnpm db:reset:migrations` plus schema lint
- all database contracts — 133/133; account deletion — 39/39
- legacy opaque-identity migration replay — 6/6
- Deno Edge/Worker tests — 10/10; Deno checks passed
- local synthetic Auth/Mailpit OTP/PostgREST/Storage/Edge hard-delete journey passed
- Wrangler 4.114.0 dry-run passed
- HTML evidence validated, rendered, and visually inspected
- `pnpm agent:validate` and `git diff --check`

`pnpm smoke:mobile` passed its 25 deterministic tests and stopped at the documented Maestro credential boundary because the authorized local `OLW_SMOKE_DEV_CODE` profile is absent.

## Release boundary

This PR does not apply a production migration, deploy an Edge Function or Worker, configure secrets, upload a signed binary, delete a real account, or promote a store release. The linked Supabase project currently has no preview branch; representative provider rehearsal and signed physical-device proof remain explicit follow-up gates.
